### PR TITLE
Fix phi copies at surviving region exits

### DIFF
--- a/dexdec/src/ir/analysis/source_variables/phi.rs
+++ b/dexdec/src/ir/analysis/source_variables/phi.rs
@@ -1934,6 +1934,7 @@ pub(super) struct PhiLowering {
     handler_entries: BTreeMap<BlockId, Vec<SemanticStatement>>,
     handler_regions: BTreeMap<RegionId, BlockId>,
     handler_blocks: BTreeSet<BlockId>,
+    semantic_blocks: BTreeSet<BlockId>,
     statement_blocks: BTreeSet<BlockId>,
     placed_exceptional: BTreeSet<InstructionId>,
     seen: BTreeSet<BlockId>,
@@ -2063,6 +2064,7 @@ impl PhiLowering {
             handler_entries,
             handler_regions,
             handler_blocks,
+            semantic_blocks: BTreeSet::new(),
             statement_blocks: BTreeSet::new(),
             placed_exceptional: BTreeSet::new(),
             seen: BTreeSet::new(),
@@ -2075,6 +2077,7 @@ impl PhiLowering {
     }
 
     pub(super) fn apply(mut self, root: &mut SemanticNode) -> Result<(), SourceVariableError> {
+        self.semantic_blocks = SemanticBlocks::collect(root);
         self.statement_blocks = StatementBlocks::collect(root);
         let body = std::mem::replace(root, SemanticNode::Empty);
         *root = self.fold_node(body)?;
@@ -2300,16 +2303,19 @@ impl PhiLowering {
             .origin
             .and_then(|origin| {
                 self.seen.insert(origin);
-                let sites = leave
-                    .edge
-                    .into_iter()
-                    .flat_map(|edge| {
-                        [
-                            NormalCopySite::Edge(edge),
-                            NormalCopySite::Block(edge.target),
-                        ]
-                    })
-                    .chain(std::iter::once(NormalCopySite::Block(origin)));
+                let mut sites = Vec::with_capacity(3);
+                if let Some(edge) = leave.edge {
+                    sites.push(NormalCopySite::Edge(edge));
+                    // A surviving target block owns its block-local copies.
+                    // Lifting those copies onto this leave would execute them
+                    // once before the transfer and again when the target is
+                    // lowered. Only absorb target copies when structural
+                    // recovery removed the target's semantic identity.
+                    if !self.semantic_blocks.contains(&edge.target) {
+                        sites.push(NormalCopySite::Block(edge.target));
+                    }
+                }
+                sites.push(NormalCopySite::Block(origin));
                 self.normal.place_once_on_path(sites).map(|statements| {
                     SemanticNode::BasicBlock(SemanticBlock {
                         id: origin,

--- a/dexdec/tests/integration_test.rs
+++ b/dexdec/tests/integration_test.rs
@@ -6,6 +6,7 @@ mod common;
 
 use dexdec::api::DecompilerContext;
 use dexdec::ir::{ArgType, MemberReference, CFG};
+use dexdec::JavaDecompilerConfig;
 
 /// Helper to compile and load a test case
 fn load_testcase(name: &str) -> (DecompilerContext, String) {
@@ -575,4 +576,25 @@ fn test_lru_cache_sim() {
         Ok(None) => panic!("Analyzed trimToSize returned None"),
         Err(e) => panic!("Error decompiling trimToSize: {:?}", e),
     }
+}
+
+#[test]
+fn test_synchronized_loop_phi_copy_is_not_duplicated_at_region_exit() {
+    let (mut ctx, class_name) = load_testcase("SynchronizedAdvanced");
+    ctx.load_all_classes().expect("test classes should load");
+
+    let code = ctx
+        .decompile_java_method_with_config(
+            &class_name,
+            "deepNesting",
+            Some("([I)I"),
+            &JavaDecompilerConfig::default(),
+        )
+        .expect("deepNesting should decompile")
+        .expect("deepNesting should be present");
+
+    assert!(code.contains("while (index < values.length)"), "{code}");
+    assert!(code.contains("index++;"), "{code}");
+    assert!(!code.contains("int v2 = 0;"), "{code}");
+    assert!(!code.contains("index = v2;"), "{code}");
 }

--- a/dexdec/tests/testcases/expected/ExceptionControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/ExceptionControlFlow.kt.expected
@@ -91,14 +91,10 @@ public open class ExceptionControlFlow {
             var total: Int = 0
             while (index < values!!.size) {
                 try {
-                    var v2: Int = 0
                     if (values[index] != 0) {
                         total += 10 / values[index]
-                    } else {
-                        index = v2
                     }
-                    v2 = index + 1
-                    index = v2
+                    index++
                 } catch (exception: ArithmeticException) {
                     return total
                 }

--- a/dexdec/tests/testcases/expected/ExceptionControlFlowAdvanced.kt.expected
+++ b/dexdec/tests/testcases/expected/ExceptionControlFlowAdvanced.kt.expected
@@ -5,7 +5,6 @@ public open class ExceptionControlFlowAdvanced {
             var count: Int = 0
             while (index < values!!.size) {
                 try {
-                    var v2: Int = 0
                     if (values[index] != 0) {
                         if (values[index] < 0) {
                             count++
@@ -14,10 +13,8 @@ public open class ExceptionControlFlowAdvanced {
                         count = count + values[index] + 1
                     } else {
                         count++
-                        index = v2
                     }
-                    v2 = index + 1
-                    index = v2
+                    index++
                 } catch (exception: Throwable) {
                     throw exception
                 }

--- a/dexdec/tests/testcases/expected/HardcoreControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/HardcoreControlFlow.kt.expected
@@ -91,7 +91,6 @@ public open class HardcoreControlFlow {
         var index: Int = 0
         var total: Int = 0
         while (index < valueses.size) {
-            var v3: Int = 0
             if (valueses[index] !== null) {
                 var index2: Int = 0
                 var condition: Boolean = false
@@ -112,7 +111,6 @@ public open class HardcoreControlFlow {
                     while (step < element) {
                         if (step * index2 > 1000) {
                             total += step
-                            index = v3
                             condition = true
                             break
                         }
@@ -126,8 +124,7 @@ public open class HardcoreControlFlow {
                     continue
                 }
             }
-            v3 = index + 1
-            index = v3
+            index++
         }
         return total
     }
@@ -138,7 +135,6 @@ public open class HardcoreControlFlow {
         var selector: Int = 0
         while (index < values.size) {
             val step: Int = values[index]
-            var v3: Int = 0
             when (selector) {
                 0 -> {
                     if (step > 0) {
@@ -150,7 +146,6 @@ public open class HardcoreControlFlow {
                         return total
                     }
                     selector = 2
-                    index = v3
                 }
                 1 -> {
                     if (step != 0) {
@@ -168,8 +163,7 @@ public open class HardcoreControlFlow {
                     return -1
                 }
             }
-            v3 = index + 1
-            index = v3
+            index++
         }
         return total
     }

--- a/dexdec/tests/testcases/expected/SynchronizedAdvanced.kt.expected
+++ b/dexdec/tests/testcases/expected/SynchronizedAdvanced.kt.expected
@@ -17,17 +17,14 @@ public open class SynchronizedAdvanced {
             var index: Int = 0
             var remaining: Int = 0
             while (index < values!!.size) {
-                var v2: Int = 0
                 synchronized(SynchronizedAdvanced.lock1!!) {
                     try {
                         remaining += 10 / values[index]
                     } catch (exception: ArithmeticException) {
                         remaining--
                     }
-                    index = v2
                 }
-                v2 = index + 1
-                index = v2
+                index++
             }
             return remaining
         }


### PR DESCRIPTION
## Summary

- keep block-local phi copies on a target block when that block survives semantic structuring
- only absorb a target block's copies into a region leave when the target's semantic identity was removed
- add an end-to-end Java regression for `SynchronizedAdvanced.deepNesting`
- refresh affected Kotlin snapshots that previously contained the duplicated copy

## Root cause

For a leave such as `B11 -> B12`, phi lowering considered the edge, target block, and origin as interchangeable copy sites. It consumed `B12`'s block-local loop-index copy while lowering the leave out of the synchronized region. Because `B12` still survived as a semantic block with statements, `lower_block` emitted the same copy again.

The Java definite-assignment pass then initialized the prematurely referenced temporary to zero, producing code equivalent to:

```java
index = 0;
while (index < values.length) {
    synchronized (lock) {
        index = v2;
    }
    v2 = index + 1;
    index = v2;
}
```

For arrays longer than one element this resets the loop index and can make the decompiled program never return.

## Verification

- `cargo fmt --all -- --check`
- 332 library tests passed
- 46 selected local integration/snapshot tests passed
- release CLI decompiled all 29 fixture classes successfully
- the regenerated `deepNesting` source compiles and returns `9` for `[1, 2, 0, -2]`
- behavioral comparison against the original fixture: 197 inputs, 0 failures, including the multi-element `deepNesting` case

The external-corpus test could not run in this checkout because its configured `refer/art/test/003-omnibus-opcodes/src` source root is absent.
