### PR TITLE
Fix Java loop constant propagation dropping state resets

### DIFF
--- a/dexdec/src/language/java/assignment.rs
+++ b/dexdec/src/language/java/assignment.rs
@@ -140,6 +140,7 @@ impl KnownValues {
             JavaStmt::While {
                 condition, body, ..
             } => {
+                self.forget_statement_writes(body);
                 self.invalidate(condition);
                 let incoming = self.values.clone();
                 let result = self.branch(body, &incoming).0;
@@ -152,6 +153,7 @@ impl KnownValues {
             JavaStmt::DoWhile {
                 body, condition, ..
             } => {
+                self.forget_statement_writes(body);
                 let incoming = self.values.clone();
                 let result = self.branch(body, &incoming).0;
                 self.invalidate(condition);
@@ -169,6 +171,8 @@ impl KnownValues {
                 ..
             } => {
                 let mut result = self.sequence(init);
+                self.forget_statement_writes(body);
+                self.forget_expression_writes(update);
                 if let Some(condition) = condition {
                     self.invalidate(condition);
                 }
@@ -183,6 +187,7 @@ impl KnownValues {
                 result
             }
             JavaStmt::ForEach { iterable, body, .. } => {
+                self.forget_statement_writes(body);
                 self.invalidate(iterable);
                 let incoming = self.values.clone();
                 let result = self.branch(body, &incoming).0;
@@ -276,6 +281,26 @@ impl KnownValues {
         }
     }
 
+    fn forget_statement_writes(&mut self, statement: &JavaStmt) {
+        let mut writes = StatementWrites::default();
+        writes.collect(statement);
+        self.forget_names(writes.names);
+    }
+
+    fn forget_expression_writes(&mut self, expressions: &[JavaExpr]) {
+        let mut writes = ExpressionWrites::default();
+        for expression in expressions {
+            writes.rewrite_expression(expression.clone());
+        }
+        self.forget_names(writes.names);
+    }
+
+    fn forget_names(&mut self, names: BTreeSet<JavaIdentifier>) {
+        for name in names {
+            self.values.remove(&name);
+        }
+    }
+
     fn complete(changed: bool) -> RewriteResult {
         RewriteResult {
             changed,
@@ -307,6 +332,62 @@ impl JavaAstRewriter for ExpressionWrites {
             _ => {}
         }
         expression
+    }
+}
+
+#[derive(Default)]
+struct StatementWrites {
+    names: BTreeSet<JavaIdentifier>,
+}
+
+impl StatementWrites {
+    fn collect(&mut self, statement: &JavaStmt) {
+        self.rewrite_statement(statement.clone());
+    }
+
+    fn record_target(&mut self, target: &JavaExpr) {
+        if let JavaExpr::Name(name) = target {
+            self.names.insert(name.clone());
+        }
+    }
+}
+
+impl JavaAstRewriter for StatementWrites {
+    fn rewrite_nested_functions(&self) -> bool {
+        false
+    }
+
+    fn finish_expression(&mut self, expression: JavaExpr) -> JavaExpr {
+        if let JavaExpr::Assignment { target, .. } | JavaExpr::Update { target, .. } = &expression {
+            self.record_target(target);
+        }
+        expression
+    }
+
+    fn finish_statement(&mut self, statement: JavaStmt) -> JavaStmt {
+        match &statement {
+            JavaStmt::Variable { name, .. } | JavaStmt::ForEach { variable: name, .. } => {
+                self.names.insert(name.clone());
+            }
+            JavaStmt::Assign { target, .. } => self.record_target(target),
+            JavaStmt::Empty
+            | JavaStmt::Block(_)
+            | JavaStmt::Labeled { .. }
+            | JavaStmt::Expression(_)
+            | JavaStmt::ConstructorInvocation { .. }
+            | JavaStmt::If { .. }
+            | JavaStmt::While { .. }
+            | JavaStmt::DoWhile { .. }
+            | JavaStmt::For { .. }
+            | JavaStmt::Switch { .. }
+            | JavaStmt::Try { .. }
+            | JavaStmt::Synchronized { .. }
+            | JavaStmt::Return(_)
+            | JavaStmt::Throw(_)
+            | JavaStmt::Break(_)
+            | JavaStmt::Continue(_) => {}
+        }
+        statement
     }
 }
 

--- a/dexdec/src/language/java/syntax/conditions.rs
+++ b/dexdec/src/language/java/syntax/conditions.rs
@@ -471,6 +471,14 @@ impl PathConditionDomain {
         }
     }
 
+    fn invalidate_after_statement(
+        &self,
+        known: &mut BooleanState,
+        statement: &crate::ir::SemanticStatement,
+    ) {
+        known.invalidate(statement.result().and_then(|result| result.code_var));
+    }
+
     fn variables_after(
         &self,
         mut known: BooleanState,
@@ -1118,8 +1126,10 @@ impl PathConditionReduction {
                     } => {
                         let site = test.condition.site;
                         let condition = test.condition.into_inner();
-                        let mut body_state = known.clone();
-                        self.domain.invalidate_after(&mut body_state, &test.setup);
+                        let mut header_state = known.clone();
+                        self.domain.invalidate_after(&mut header_state, &test.setup);
+                        self.domain.invalidate_after(&mut header_state, &body);
+                        let mut body_state = header_state.clone();
                         if kind == SemanticLoopKind::PreTested {
                             body_state =
                                 self.domain.assume_variables(&body_state, &condition, true);
@@ -1148,7 +1158,7 @@ impl PathConditionReduction {
                         tasks.push(ReductionTask::Visit {
                             node: *test.setup,
                             care,
-                            known,
+                            known: header_state,
                         });
                     }
                     SemanticNode::For {
@@ -1160,7 +1170,13 @@ impl PathConditionReduction {
                     } => {
                         let site = condition.site;
                         let condition = condition.into_inner();
-                        let body_state = self.domain.assume_variables(&known, &condition, true);
+                        let mut header_state = known.clone();
+                        self.domain.invalidate_after(&mut header_state, &body);
+                        self.domain
+                            .invalidate_after_statement(&mut header_state, &update);
+                        let body_state =
+                            self.domain
+                                .assume_variables(&header_state, &condition, true);
                         let fact = self.domain.simplify(condition, care);
                         self.changed |= fact.changed;
                         let body_care = self.domain.assume(care, fact.value, true);
@@ -1185,6 +1201,8 @@ impl PathConditionReduction {
                         iterable,
                         body,
                     } => {
+                        let mut body_state = known;
+                        self.domain.invalidate_after(&mut body_state, &body);
                         tasks.push(ReductionTask::Rebuild(ReductionFrame::ForEach {
                             control,
                             variable,
@@ -1193,7 +1211,7 @@ impl PathConditionReduction {
                         tasks.push(ReductionTask::Visit {
                             node: *body,
                             care,
-                            known,
+                            known: body_state,
                         });
                     }
                     SemanticNode::Switch {

--- a/dexdec/tests/integration_test.rs
+++ b/dexdec/tests/integration_test.rs
@@ -598,3 +598,21 @@ fn test_synchronized_loop_phi_copy_is_not_duplicated_at_region_exit() {
     assert!(!code.contains("int v2 = 0;"), "{code}");
     assert!(!code.contains("index = v2;"), "{code}");
 }
+
+#[test]
+fn test_java_state_machine_preserves_switch_state_resets() {
+    let (mut ctx, class_name) = load_testcase("HardcoreControlFlow");
+    ctx.load_all_classes().expect("test classes should load");
+
+    let code = ctx
+        .decompile_java_method_with_config(
+            &class_name,
+            "stateMachine",
+            Some("([I)I"),
+            &JavaDecompilerConfig::default(),
+        )
+        .expect("stateMachine should decompile")
+        .expect("stateMachine should be present");
+
+    assert_eq!(code.matches("selector = 0;").count(), 3, "{code}");
+}


### PR DESCRIPTION
## Summary

Fix Java decompilation dropping loop-carried state assignments in `HardcoreControlFlow.stateMachine`.

The original DEX resets the state variable to zero in both `case 1` and `case 2`, but the Java backend removed both assignments:

```java
case 1:
    if (step != 0) {
        total *= 2;
        index++;
        break;
    }
    selector = 0;
    break;
case 2:
    total -= step;
    selector = 0;
    break;
```

Without these resets, the generated Java changes control-flow semantics. For example, the original method returns `5` for `[1, 0, 4]`, while the previous Java output returned `2`.

## Root cause

Two Java passes independently propagated the loop preheader fact `selector == 0` into the loop body without accounting for the backedge:

1. `PathConditionReduction` treated values known before a semantic loop as known on every iteration.
2. `DefiniteAssignment::KnownValues` repeated the same assumption after lowering to the Java AST.

At the loop header, `selector` can come either from the initial entry or from the previous iteration, where it may have been assigned `0`, `1`, or `2`. Therefore it is not a loop invariant. Each pass could independently classify `selector = 0` as redundant, so both layers need the same loop-aware invalidation.

## Fix

- Invalidate known values written by semantic loop setup/body/update nodes before reducing the loop body.
- Collect Java AST statement and expression writes and forget those values before propagating constants through `while`, `do-while`, `for`, and enhanced `for` bodies.
- Add a Java integration regression test using the repository's existing `HardcoreControlFlow` DEX fixture. The test requires the initializer and both state-reset assignments to remain in generated Java.

This is conservative: variables not modified by the loop can still be propagated, while loop-carried variables are no longer treated as constants.

## Cross-check

- The Kotlin backend already invalidates loop body/update writes and preserves both assignments.
- JADX output for the same DEX also preserves both resets. Its constant handling is SSA-based and avoids propagating constants through loop PHI values, which is consistent with this fix.

## Verification

- Fresh Java decompilation contains all three `selector = 0;` occurrences: one initializer and two branch assignments.
- The generated Java compiles with `javac`.
- Generated and original Java return identical results for seven inputs covering empty input, both state-reset paths, skip behavior, and early return.
- Critical input `[1, 0, 4]` returns `5` after the fix.
- `cargo check -p dexdec` passes.
- 332 library tests pass.
- 24 integration tests pass, including the new regression.
- Expected-output, constructor, override-analysis, platform-symbol, platform-contract, and reference-query tests pass.

No CI files are changed.

## Existing unrelated test limitations

- The repository's current `cli_args_test` does not compile against `origin/main` because it still references the removed `Cli::into_command` API and `include_inner` field.
- `external_corpus_test` requires the optional `refer/art/...` source corpus, which is not present in this checkout.
