### PR TITLE
Bound large-APK decompilation and emit legal Java syntax

### DIFF
--- a/dexdec/src/analysis/java_backend/constructor_syntax.rs
+++ b/dexdec/src/analysis/java_backend/constructor_syntax.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::language::java::{
     JavaAssignOp, JavaAstRewriter, JavaBinaryOp, JavaConstructorTarget, JavaExpr, JavaIdentifier,
-    JavaLiteral, JavaMethodDeclarationKind, JavaStmt, JavaType, JavaTypeDeclaration, JavaUnaryOp,
+    JavaLiteral, JavaMethodDeclarationKind, JavaStmt, JavaType, JavaTypeDeclaration,
+    JavaTypeDeclarationKind, JavaUnaryOp,
 };
 
 /// Removes constructor syntax that Java inserts implicitly.
@@ -10,6 +11,7 @@ pub(super) struct ConstructorSyntaxRecovery;
 
 impl ConstructorSyntaxRecovery {
     pub(super) fn apply(declaration: &mut JavaTypeDeclaration) {
+        let is_enum = declaration.kind == JavaTypeDeclarationKind::Enum;
         let final_fields = declaration
             .fields
             .iter()
@@ -31,16 +33,28 @@ impl ConstructorSyntaxRecovery {
             let JavaStmt::Block(statements) = &mut body.root else {
                 continue;
             };
-            ConstructorCapturePrelude::schedule(
-                statements,
-                &constructor
-                    .parameters
-                    .iter()
-                    .map(|parameter| parameter.name.clone())
-                    .collect(),
-                &final_fields,
-            );
+            let parameters = constructor
+                .parameters
+                .iter()
+                .map(|parameter| parameter.name.clone())
+                .collect::<BTreeSet<_>>();
+            let guards = ConstructorParameterGuards::take(statements, &parameters);
+            ConstructorCapturePrelude::schedule(statements, &parameters, &final_fields);
             Self::schedule_arguments(statements);
+            ConstructorParameterGuards::restore(statements, guards);
+            if is_enum {
+                // Java enum constructors invoke java.lang.Enum implicitly and
+                // reject an explicit super(name, ordinal) invocation.
+                statements.retain(|statement| {
+                    !matches!(
+                        statement,
+                        JavaStmt::ConstructorInvocation {
+                            target: JavaConstructorTarget::Super,
+                            ..
+                        }
+                    )
+                });
+            }
             if matches!(
                 statements.first(),
                 Some(JavaStmt::ConstructorInvocation {
@@ -91,6 +105,67 @@ impl ConstructorSyntaxRecovery {
 
 struct ConstructorCapturePrelude;
 
+struct ConstructorParameterGuards;
+
+impl ConstructorParameterGuards {
+    fn take(
+        statements: &mut Vec<JavaStmt>,
+        parameters: &BTreeSet<JavaIdentifier>,
+    ) -> Vec<JavaStmt> {
+        let Some(invocation) = statements
+            .iter()
+            .position(|statement| matches!(statement, JavaStmt::ConstructorInvocation { .. }))
+        else {
+            return Vec::new();
+        };
+        let leading = statements[..invocation]
+            .iter()
+            .take_while(|statement| Self::is_parameter_guard(statement, parameters))
+            .count();
+        statements.drain(..leading).collect()
+    }
+
+    fn restore(statements: &mut Vec<JavaStmt>, guards: Vec<JavaStmt>) {
+        if guards.is_empty() {
+            return;
+        }
+        let Some(0) = statements
+            .iter()
+            .position(|statement| matches!(statement, JavaStmt::ConstructorInvocation { .. }))
+        else {
+            statements.splice(0..0, guards);
+            return;
+        };
+        statements.splice(1..1, guards);
+    }
+
+    fn is_parameter_guard(statement: &JavaStmt, parameters: &BTreeSet<JavaIdentifier>) -> bool {
+        let JavaStmt::Expression(JavaExpr::Call {
+            receiver: None,
+            owner: Some(JavaType::Class(owner)),
+            method,
+            args,
+            ..
+        }) = statement
+        else {
+            return false;
+        };
+        let is_intrinsics = owner
+            .name()
+            .components()
+            .last()
+            .is_some_and(|component| component.as_str() == "Intrinsics");
+        is_intrinsics
+            && matches!(
+                method.as_str(),
+                "checkNotNullParameter" | "checkParameterIsNotNull"
+            )
+            && args
+                .first()
+                .is_some_and(|value| ConstructorCapturePrelude::is_capture_value(value, parameters))
+    }
+}
+
 impl ConstructorCapturePrelude {
     fn schedule(
         statements: &mut Vec<JavaStmt>,
@@ -127,12 +202,18 @@ impl ConstructorCapturePrelude {
                 ..
             } if matches!(owner.as_ref(), JavaExpr::This)
                 && final_fields.contains(field)
-                && match value {
-                    JavaExpr::Name(parameter) => parameters.contains(parameter),
-                    JavaExpr::QualifiedThis(_) => true,
-                    _ => false,
-                }
+                && Self::is_capture_value(value, parameters)
         )
+    }
+
+    fn is_capture_value(value: &JavaExpr, parameters: &BTreeSet<JavaIdentifier>) -> bool {
+        match value {
+            JavaExpr::Name(parameter) => parameters.contains(parameter),
+            JavaExpr::QualifiedThis(_) => true,
+            JavaExpr::Literal(_) => true,
+            JavaExpr::Cast { value, .. } => Self::is_capture_value(value, parameters),
+            _ => false,
+        }
     }
 }
 
@@ -844,5 +925,105 @@ impl ExpressionNames {
             }
         }
         names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{ConstructorCapturePrelude, ConstructorParameterGuards, ConstructorSyntaxRecovery};
+    use crate::language::java::{
+        JavaAssignOp, JavaConstructorTarget, JavaExpr, JavaIdentifier, JavaStmt, JavaType,
+    };
+
+    #[test]
+    fn casted_capture_stores_move_after_the_super_invocation() {
+        let parameter = JavaIdentifier::from_dex("captured");
+        let field = JavaIdentifier::from_dex("field");
+        let constant_field = JavaIdentifier::from_dex("constantField");
+        let mut statements = vec![
+            JavaStmt::Assign {
+                target: JavaExpr::Field {
+                    owner: Box::new(JavaExpr::This),
+                    name: field.clone(),
+                },
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Cast {
+                    ty: JavaType::source_class("java.util.List"),
+                    value: Box::new(JavaExpr::Name(parameter.clone())),
+                },
+            },
+            JavaStmt::Assign {
+                target: JavaExpr::Field {
+                    owner: Box::new(JavaExpr::This),
+                    name: constant_field.clone(),
+                },
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Literal(crate::language::java::JavaLiteral::Integer(0)),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                args: vec![JavaExpr::Literal(
+                    crate::language::java::JavaLiteral::Integer(2),
+                )],
+            },
+        ];
+
+        ConstructorCapturePrelude::schedule(
+            &mut statements,
+            &BTreeSet::from([parameter]),
+            &BTreeSet::from([field, constant_field]),
+        );
+
+        assert!(matches!(
+            statements.first(),
+            Some(JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn kotlin_parameter_guards_move_after_the_super_invocation() {
+        let parameter = JavaIdentifier::from_dex("context");
+        let alias = JavaIdentifier::from_dex("checkedContext");
+        let mut statements = vec![
+            JavaStmt::Expression(JavaExpr::Call {
+                receiver: None,
+                owner: Some(JavaType::source_class("kotlin.jvm.internal.Intrinsics")),
+                type_arguments: Vec::new(),
+                method: JavaIdentifier::from_dex("checkNotNullParameter"),
+                args: vec![
+                    JavaExpr::Name(parameter.clone()),
+                    JavaExpr::Literal(crate::language::java::JavaLiteral::String(
+                        crate::ir::Utf16String::from("context"),
+                    )),
+                ],
+            }),
+            JavaStmt::Variable {
+                ty: JavaType::source_class("android.content.Context"),
+                name: alias.clone(),
+                value: Some(JavaExpr::Name(parameter.clone())),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                args: vec![JavaExpr::Name(alias)],
+            },
+        ];
+
+        let parameters = BTreeSet::from([parameter]);
+        let guards = ConstructorParameterGuards::take(&mut statements, &parameters);
+        ConstructorSyntaxRecovery::schedule_arguments(&mut statements);
+        ConstructorParameterGuards::restore(&mut statements, guards);
+
+        assert!(matches!(
+            statements.first(),
+            Some(JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                ..
+            })
+        ));
     }
 }

--- a/dexdec/src/analysis/java_backend/constructor_syntax.rs
+++ b/dexdec/src/analysis/java_backend/constructor_syntax.rs
@@ -448,7 +448,8 @@ impl ConstructorBindings {
             | JavaExpr::Super
             | JavaExpr::Name(_)
             | JavaExpr::Literal(_)
-            | JavaExpr::ClassLiteral(_) => true,
+            | JavaExpr::ClassLiteral(_)
+            | JavaExpr::StaticField { .. } => true,
             JavaExpr::Cast { value, .. } => Self::stable(value),
             _ => false,
         }
@@ -1024,6 +1025,34 @@ mod tests {
                 target: JavaConstructorTarget::Super,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn static_field_bindings_inline_into_constructor_arguments() {
+        let binding = JavaIdentifier::from_dex("trueValue");
+        let value = JavaExpr::StaticField {
+            owner: JavaType::source_class("java.lang.Boolean"),
+            name: JavaIdentifier::from_dex("TRUE"),
+        };
+        let mut statements = vec![
+            JavaStmt::Variable {
+                ty: JavaType::source_class("java.lang.Boolean"),
+                name: binding.clone(),
+                value: Some(value.clone()),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                args: vec![JavaExpr::Name(binding.clone()), JavaExpr::Name(binding)],
+            },
+        ];
+
+        ConstructorSyntaxRecovery::schedule_arguments(&mut statements);
+
+        assert!(matches!(
+            statements.as_slice(),
+            [JavaStmt::ConstructorInvocation { args, .. }]
+                if args == &vec![value.clone(), value]
         ));
     }
 }

--- a/dexdec/src/ir/analysis/semantic_flow.rs
+++ b/dexdec/src/ir/analysis/semantic_flow.rs
@@ -5,6 +5,7 @@
 //! one original CFG block.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::{Arc, Mutex};
 
 use crate::ir::{
     RegionId, SemanticExpression, SemanticLabel, SemanticLeave, SemanticLeaveKind,
@@ -49,7 +50,28 @@ pub struct SemanticFlowGraph {
 #[derive(Debug, Clone)]
 pub struct SemanticReachability {
     components: BTreeMap<SemanticFlowPoint, usize>,
-    reachable: Vec<DefinitionSet>,
+    store: ReachabilityStore,
+}
+
+#[derive(Debug, Clone)]
+enum ReachabilityStore {
+    Dense(Vec<DefinitionSet>),
+    Sparse(Arc<SparseReachability>),
+}
+
+#[derive(Debug)]
+struct SparseReachability {
+    successors: Vec<Vec<usize>>,
+    predecessors: Vec<Vec<usize>>,
+    topological_positions: Vec<usize>,
+    forward: Mutex<ReachabilityCache>,
+    backward: Mutex<ReachabilityCache>,
+}
+
+#[derive(Debug, Default)]
+struct ReachabilityCache {
+    order: VecDeque<usize>,
+    rows: BTreeMap<usize, Arc<DefinitionSet>>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -198,6 +220,11 @@ impl SemanticReachingValues {
 
 impl SemanticReachability {
     fn analyze(graph: &SemanticFlowGraph) -> Self {
+        const MAX_DENSE_BYTES: usize = 64 * 1024 * 1024;
+        Self::analyze_with_dense_limit(graph, MAX_DENSE_BYTES)
+    }
+
+    fn analyze_with_dense_limit(graph: &SemanticFlowGraph, max_dense_bytes: usize) -> Self {
         let points = graph
             .predecessors
             .keys()
@@ -292,23 +319,49 @@ impl SemanticReachability {
         }
         debug_assert_eq!(topological.len(), component_count);
 
-        let mut reachable = (0..component_count)
-            .map(|component| {
-                let mut set = DefinitionSet::new(component_count);
-                set.insert(component);
-                set
-            })
-            .collect::<Vec<_>>();
-        for component in topological.into_iter().rev() {
-            for successor in &successors[component] {
-                let successor_reachability = reachable[*successor].clone();
-                reachable[component].union_with(&successor_reachability);
+        let words_per_row = component_count.div_ceil(u64::BITS as usize);
+        let dense_bytes = component_count
+            .saturating_mul(words_per_row)
+            .saturating_mul(std::mem::size_of::<u64>());
+        let store = if dense_bytes <= max_dense_bytes {
+            let mut reachable = (0..component_count)
+                .map(|component| {
+                    let mut set = DefinitionSet::new(component_count);
+                    set.insert(component);
+                    set
+                })
+                .collect::<Vec<_>>();
+            for component in topological.into_iter().rev() {
+                for successor in &successors[component] {
+                    let successor_reachability = reachable[*successor].clone();
+                    reachable[component].union_with(&successor_reachability);
+                }
             }
-        }
-        Self {
-            components,
-            reachable,
-        }
+            ReachabilityStore::Dense(reachable)
+        } else {
+            let successors = successors
+                .into_iter()
+                .map(|targets| targets.into_iter().collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+            let mut predecessors = vec![Vec::new(); component_count];
+            for (source, targets) in successors.iter().enumerate() {
+                for target in targets {
+                    predecessors[*target].push(source);
+                }
+            }
+            let mut topological_positions = vec![0; component_count];
+            for (position, component) in topological.into_iter().enumerate() {
+                topological_positions[component] = position;
+            }
+            ReachabilityStore::Sparse(Arc::new(SparseReachability {
+                successors,
+                predecessors,
+                topological_positions,
+                forward: Mutex::new(ReachabilityCache::default()),
+                backward: Mutex::new(ReachabilityCache::default()),
+            }))
+        };
+        Self { components, store }
     }
 
     pub fn reaches(&self, source: SemanticFlowPoint, target: SemanticFlowPoint) -> bool {
@@ -317,7 +370,10 @@ impl SemanticReachability {
         else {
             return false;
         };
-        self.reachable[*source].contains(*target)
+        match &self.store {
+            ReachabilityStore::Dense(reachable) => reachable[*source].contains(*target),
+            ReachabilityStore::Sparse(reachable) => reachable.reaches(*source, *target),
+        }
     }
 
     pub fn reaches_any_between(
@@ -326,9 +382,90 @@ impl SemanticReachability {
         target: SemanticFlowPoint,
         candidates: &BTreeSet<SemanticFlowPoint>,
     ) -> bool {
-        candidates
-            .iter()
-            .any(|candidate| self.reaches(source, *candidate) && self.reaches(*candidate, target))
+        match &self.store {
+            ReachabilityStore::Dense(_) => candidates.iter().any(|candidate| {
+                self.reaches(source, *candidate) && self.reaches(*candidate, target)
+            }),
+            ReachabilityStore::Sparse(reachable) => {
+                let (Some(source), Some(target)) =
+                    (self.components.get(&source), self.components.get(&target))
+                else {
+                    return false;
+                };
+                let from_source = reachable.forward_row(*source);
+                let to_target = reachable.backward_row(*target);
+                candidates.iter().any(|candidate| {
+                    self.components.get(candidate).is_some_and(|candidate| {
+                        from_source.contains(*candidate) && to_target.contains(*candidate)
+                    })
+                })
+            }
+        }
+    }
+}
+
+impl SparseReachability {
+    const MAX_CACHED_ROWS: usize = 32;
+
+    fn reaches(&self, source: usize, target: usize) -> bool {
+        if source == target {
+            return true;
+        }
+        if self.topological_positions[source] >= self.topological_positions[target] {
+            return false;
+        }
+        self.forward_row(source).contains(target)
+    }
+
+    fn forward_row(&self, source: usize) -> Arc<DefinitionSet> {
+        Self::row(&self.forward, &self.successors, source)
+    }
+
+    fn backward_row(&self, target: usize) -> Arc<DefinitionSet> {
+        Self::row(&self.backward, &self.predecessors, target)
+    }
+
+    fn row(
+        cache: &Mutex<ReachabilityCache>,
+        adjacency: &[Vec<usize>],
+        source: usize,
+    ) -> Arc<DefinitionSet> {
+        if let Some(row) = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .rows
+            .get(&source)
+            .cloned()
+        {
+            return row;
+        }
+
+        let mut row = DefinitionSet::new(adjacency.len());
+        let mut pending = vec![source];
+        while let Some(component) = pending.pop() {
+            if row.contains(component) {
+                continue;
+            }
+            row.insert(component);
+            pending.extend(adjacency[component].iter().copied());
+        }
+        let row = Arc::new(row);
+
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(existing) = cache.rows.get(&source) {
+            return existing.clone();
+        }
+        while cache.rows.len() >= Self::MAX_CACHED_ROWS {
+            let Some(evicted) = cache.order.pop_front() else {
+                break;
+            };
+            cache.rows.remove(&evicted);
+        }
+        cache.order.push_back(source);
+        cache.rows.insert(source, row.clone());
+        row
     }
 }
 
@@ -1692,6 +1829,47 @@ mod tests {
         };
 
         assert!(!graph.must_reach(source, target));
+    }
+
+    #[test]
+    fn sparse_reachability_matches_dense_reachability() {
+        let points = (0..7).map(point).collect::<Vec<_>>();
+        let mut graph = SemanticFlowGraph {
+            complete: true,
+            ..SemanticFlowGraph::default()
+        };
+        for (source, target) in [(0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (4, 3), (4, 5)] {
+            graph
+                .successors
+                .entry(points[source])
+                .or_default()
+                .push(points[target]);
+            graph
+                .predecessors
+                .entry(points[target])
+                .or_default()
+                .push((points[source], SemanticFlowEdgeKind::Normal));
+        }
+        graph.entries.insert(points[0]);
+
+        let dense = SemanticReachability::analyze_with_dense_limit(&graph, usize::MAX);
+        let sparse = SemanticReachability::analyze_with_dense_limit(&graph, 0);
+        assert!(matches!(sparse.store, ReachabilityStore::Sparse(_)));
+        for source in &points {
+            for target in &points {
+                assert_eq!(
+                    sparse.reaches(*source, *target),
+                    dense.reaches(*source, *target),
+                    "reachability mismatch from {source:?} to {target:?}"
+                );
+            }
+        }
+
+        let candidates = BTreeSet::from([points[1], points[2], points[6]]);
+        assert_eq!(
+            sparse.reaches_any_between(points[0], points[5], &candidates),
+            dense.reaches_any_between(points[0], points[5], &candidates)
+        );
     }
 }
 

--- a/dexdec/src/ir/structure/flow_graph.rs
+++ b/dexdec/src/ir/structure/flow_graph.rs
@@ -348,6 +348,7 @@ impl SemanticFlowGraph {
         mut self,
         semantic: &SemanticFactory<'_>,
     ) -> Result<(SemanticNode, u32), StructureError> {
+        let mut pattern_budget = PatternReductionBudget::for_nodes(self.nodes.len());
         loop {
             self.prune();
             FragmentNormalizer::apply(&mut self)?;
@@ -359,7 +360,10 @@ impl SemanticFlowGraph {
                 .find(|component| self.is_cyclic(component))
             else {
                 if semantic.is_switch_region(self.region) {
-                    while let Some(switch) = SwitchRegion::analyze(&self)? {
+                    while pattern_budget.take() {
+                        let Some(switch) = SwitchRegion::analyze(&self)? else {
+                            break;
+                        };
                         self.collapse_switch(switch, semantic)?;
                         self.prune();
                         self.verify_lexical_domains()?;
@@ -368,7 +372,10 @@ impl SemanticFlowGraph {
                 if let Some(body) = self.structure_acyclic(semantic)? {
                     return Ok((body, self.next_id));
                 }
-                while let Some(branch) = BranchRegion::analyze(&self)? {
+                while pattern_budget.take() {
+                    let Some(branch) = BranchRegion::analyze(&self)? else {
+                        break;
+                    };
                     self.collapse_branch(branch, semantic)?;
                     self.prune();
                     self.verify_lexical_domains()?;
@@ -1982,6 +1989,30 @@ impl SwitchRegion {
 /// opcode or source-language shape.
 struct NodeSplittingBudget {
     limit: usize,
+}
+
+/// Bounds repeated whole-graph pattern searches before the equivalent lexical
+/// label fallback is used. Branch-arm discovery can be quadratic in graph size;
+/// without a shared budget, a single generated coroutine can stall an archive
+/// batch for minutes even though label lowering can finish it directly.
+struct PatternReductionBudget {
+    remaining: usize,
+}
+
+impl PatternReductionBudget {
+    fn for_nodes(nodes: usize) -> Self {
+        const WORK_BUDGET: usize = 1_000_000;
+        let nodes = nodes.max(1);
+        Self {
+            remaining: (WORK_BUDGET / nodes / nodes).clamp(4, 64),
+        }
+    }
+
+    fn take(&mut self) -> bool {
+        let available = self.remaining > 0;
+        self.remaining = self.remaining.saturating_sub(1);
+        available
+    }
 }
 
 impl NodeSplittingBudget {

--- a/dexdec/src/ir/structure/region_reducer.rs
+++ b/dexdec/src/ir/structure/region_reducer.rs
@@ -9,7 +9,7 @@ use crate::ir::semantic::SemanticFactory;
 use crate::ir::{
     BlockId, RegionGraph, RegionId, RegionKind, SemanticBlock, SemanticCatch, SemanticFinally,
     SemanticFoldError, SemanticFolder, SemanticLeave, SemanticLeaveKind, SemanticNode,
-    StructuredRegion, CFG,
+    SemanticOperation, SemanticVisitor, StructuredRegion, CFG,
 };
 
 use super::{
@@ -143,12 +143,35 @@ impl<'a> RegionReducer<'a> {
             });
         }
         Self::verify_root_labels("contracted", &root.body)?;
+        Self::verify_node_limit(root_region, "contraction", &root.body)?;
         let body = ExceptionEnvelopeCanonicalizer::new(self.cfg, self.regions).apply(root.body)?;
         Self::verify_root_labels("exception-canonicalized", &body)?;
+        Self::verify_node_limit(root_region, "exception canonicalization", &body)?;
         let mut body = LexicalLabels::uniquify(body).map_err(StructureError::from)?;
         Self::verify_root_labels("label-uniquified", &body)?;
+        Self::verify_node_limit(root_region, "label repair", &body)?;
         SemanticCleanupResolver::apply(self.regions, &mut body);
         Ok(body)
+    }
+
+    fn verify_node_limit(
+        region: RegionId,
+        stage: &'static str,
+        body: &SemanticNode,
+    ) -> Result<(), StructureError> {
+        const MAX_SEMANTIC_ITEMS: usize = 100_000;
+        let mut count = SemanticComplexity::default();
+        count.visit_node(body);
+        if count.items > MAX_SEMANTIC_ITEMS {
+            Err(StructureError::SemanticItemLimit {
+                region,
+                stage,
+                items: count.items,
+                limit: MAX_SEMANTIC_ITEMS,
+            })
+        } else {
+            Ok(())
+        }
     }
 
     fn verify_root_labels(stage: &'static str, body: &SemanticNode) -> Result<(), StructureError> {
@@ -462,6 +485,21 @@ impl<'a> RegionReducer<'a> {
             }),
             continuation,
         ])
+    }
+}
+
+#[derive(Default)]
+struct SemanticComplexity {
+    items: usize,
+}
+
+impl SemanticVisitor for SemanticComplexity {
+    fn enter_node(&mut self, _node: &SemanticNode) {
+        self.items = self.items.saturating_add(1);
+    }
+
+    fn enter_operation(&mut self, _operation: &SemanticOperation) {
+        self.items = self.items.saturating_add(1);
     }
 }
 

--- a/dexdec/src/ir/structure/region_reducer/labels.rs
+++ b/dexdec/src/ir/structure/region_reducer/labels.rs
@@ -26,7 +26,7 @@ impl LexicalLabels {
             .iter()
             .filter_map(|(label, count)| (*count > 1).then_some(*label))
             .collect::<BTreeSet<_>>();
-        let mut root = if duplicates.is_empty() {
+        let root = if duplicates.is_empty() {
             root
         } else {
             Self {
@@ -44,12 +44,12 @@ impl LexicalLabels {
 
         let mut unique = LabelDefinitions::default();
         unique.visit_node(&root);
-        for label in unique.counts.into_iter().filter_map(|(label, count)| {
-            (count == 1 && label.kind == SemanticLabelKind::Block).then_some(label)
-        }) {
-            root = LexicalLabelScope::repair(root, label)?;
-        }
-        Ok(root)
+        LexicalLabelScopes::repair(
+            root,
+            unique.counts.into_iter().filter_map(|(label, count)| {
+                (count == 1 && label.kind == SemanticLabelKind::Block).then_some(label)
+            }),
+        )
     }
 
     pub(super) fn escaped_loop(root: &SemanticNode) -> Option<SemanticLabel> {
@@ -150,36 +150,57 @@ impl SemanticVisitor for LoopLabelScopes {
 
 /// Places a block-label binding at the lowest semantic-tree ancestor that
 /// contains both its definition and every transfer targeting it.
+#[derive(Default)]
 struct LexicalLabelScope {
-    label: SemanticLabel,
     definition: Option<Vec<usize>>,
     references: Vec<Vec<usize>>,
 }
 
-impl LexicalLabelScope {
-    fn repair(root: SemanticNode, label: SemanticLabel) -> Result<SemanticNode, SemanticFoldError> {
-        let mut scope = Self {
-            label,
-            definition: None,
-            references: Vec::new(),
-        };
-        scope.analyze(&root);
-        let Some(definition) = scope.definition else {
+/// Repairs all block-label scopes with one analysis and one rewrite pass.
+///
+/// Running both passes once per label makes large irreducible methods quadratic
+/// in the number of labels and can effectively stall whole-file decompilation.
+struct LexicalLabelScopes {
+    scopes: BTreeMap<SemanticLabel, LexicalLabelScope>,
+}
+
+impl LexicalLabelScopes {
+    fn repair(
+        root: SemanticNode,
+        labels: impl IntoIterator<Item = SemanticLabel>,
+    ) -> Result<SemanticNode, SemanticFoldError> {
+        let scopes = labels
+            .into_iter()
+            .map(|label| (label, LexicalLabelScope::default()))
+            .collect::<BTreeMap<_, _>>();
+        if scopes.is_empty() {
             return Ok(root);
-        };
-        let mut binding = definition.clone();
-        for reference in &scope.references {
-            let common = binding
-                .iter()
-                .zip(reference)
-                .take_while(|(left, right)| left == right)
-                .count();
-            binding.truncate(common);
         }
-        LabelScopeRewrite {
-            label,
-            definition,
-            binding,
+        let mut scopes = Self { scopes };
+        scopes.analyze(&root);
+
+        let mut definitions = BTreeMap::new();
+        let mut bindings = BTreeMap::<Vec<usize>, Vec<SemanticLabel>>::new();
+        for (label, scope) in scopes.scopes {
+            let Some(definition) = scope.definition else {
+                continue;
+            };
+            let mut binding = definition.clone();
+            for reference in &scope.references {
+                let common = binding
+                    .iter()
+                    .zip(reference)
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                binding.truncate(common);
+            }
+            definitions.insert(definition, label);
+            bindings.entry(binding).or_default().push(label);
+        }
+
+        LabelScopesRewrite {
+            definitions,
+            bindings,
             stack: Vec::new(),
         }
         .fold_node(root)
@@ -189,18 +210,23 @@ impl LexicalLabelScope {
         let mut pending = vec![(root, Vec::new())];
         while let Some((node, path)) = pending.pop() {
             match node {
-                SemanticNode::Label { label, .. } if *label == self.label => {
-                    self.definition = Some(path.clone());
+                SemanticNode::Label { label, .. } => {
+                    if let Some(scope) = self.scopes.get_mut(label) {
+                        scope.definition = Some(path.clone());
+                    }
                 }
-                SemanticNode::Leave(leave)
-                    if matches!(
-                        &leave.kind,
+                SemanticNode::Leave(leave) => {
+                    let label = match &leave.kind {
                         SemanticLeaveKind::BreakLabel(label)
-                            | SemanticLeaveKind::ContinueLabel(label)
-                            if *label == self.label
-                    ) =>
-                {
-                    self.references.push(path.clone());
+                        | SemanticLeaveKind::ContinueLabel(label) => label,
+                        _ => {
+                            Self::push_children(node, &path, &mut pending);
+                            continue;
+                        }
+                    };
+                    if let Some(scope) = self.scopes.get_mut(label) {
+                        scope.references.push(path.clone());
+                    }
                 }
                 _ => {}
             }
@@ -266,10 +292,9 @@ impl LexicalLabelScope {
     }
 }
 
-struct LabelScopeRewrite {
-    label: SemanticLabel,
-    definition: Vec<usize>,
-    binding: Vec<usize>,
+struct LabelScopesRewrite {
+    definitions: BTreeMap<Vec<usize>, SemanticLabel>,
+    bindings: BTreeMap<Vec<usize>, Vec<SemanticLabel>>,
     stack: Vec<PathFrame>,
 }
 
@@ -278,7 +303,7 @@ struct PathFrame {
     next_child: usize,
 }
 
-impl SemanticFolder for LabelScopeRewrite {
+impl SemanticFolder for LabelScopesRewrite {
     type Error = SemanticFoldError;
 
     fn enter_node(&mut self, _node: &SemanticNode) {
@@ -304,22 +329,25 @@ impl SemanticFolder for LabelScopeRewrite {
             .pop()
             .ok_or(SemanticFoldError::MalformedWorkStack)?
             .path;
-        let node = if path == self.definition {
+        let mut node = if let Some(definition) = self.definitions.get(&path) {
             match node {
-                SemanticNode::Label { label, body } if label == self.label => *body,
+                SemanticNode::Label { label, body } if label == *definition => *body,
                 node => node,
             }
         } else {
             node
         };
-        Ok(if path == self.binding {
-            SemanticNode::Label {
-                label: self.label,
-                body: Box::new(node),
+        if let Some(bindings) = self.bindings.get(&path) {
+            // Match the previous deterministic per-label behavior: lower
+            // labels become outer scopes when several labels share one LCA.
+            for label in bindings.iter().rev() {
+                node = SemanticNode::Label {
+                    label: *label,
+                    body: Box::new(node),
+                };
             }
-        } else {
-            node
-        })
+        }
+        Ok(node)
     }
 }
 
@@ -385,5 +413,75 @@ impl SemanticFolder for LabelReferenceRewrite {
             _ => {}
         }
         Ok(node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LexicalLabels;
+    use crate::ir::{
+        BlockId, RegionId, SemanticLabel, SemanticLeave, SemanticLeaveKind, SemanticNode,
+    };
+
+    #[test]
+    fn block_label_scopes_are_repaired_in_one_tree_rewrite() {
+        let region = RegionId::new(0);
+        let label = SemanticLabel::block(region, BlockId::new(1));
+        let root = SemanticNode::Sequence(vec![
+            SemanticNode::Leave(SemanticLeave {
+                site: None,
+                condition: None,
+                kind: SemanticLeaveKind::BreakLabel(label),
+                edge: None,
+                origin: None,
+                source: region,
+                destination: region,
+                target: region,
+                cleanup: Vec::new(),
+            }),
+            SemanticNode::Label {
+                label,
+                body: Box::new(SemanticNode::Empty),
+            },
+        ]);
+
+        let repaired = LexicalLabels::uniquify(root).expect("label scope repair");
+
+        let SemanticNode::Label {
+            label: repaired_label,
+            body,
+        } = repaired
+        else {
+            panic!("shared scope must bind the label at the sequence root");
+        };
+        assert_eq!(repaired_label, label);
+        assert!(matches!(
+            *body,
+            SemanticNode::Sequence(ref children)
+                if matches!(children.get(1), Some(SemanticNode::Empty))
+        ));
+    }
+
+    #[test]
+    fn many_unique_block_labels_do_not_require_per_label_tree_rewrites() {
+        let region = RegionId::new(0);
+        let mut root = SemanticNode::Empty;
+        for block in 1..=1_000 {
+            root = SemanticNode::Label {
+                label: SemanticLabel::block(region, BlockId::new(block)),
+                body: Box::new(root),
+            };
+        }
+
+        let repaired = LexicalLabels::uniquify(root).expect("bulk label scope repair");
+
+        let mut labels = 0;
+        let mut cursor = &repaired;
+        while let SemanticNode::Label { body, .. } = cursor {
+            labels += 1;
+            cursor = body;
+        }
+        assert_eq!(labels, 1_000);
+        assert!(matches!(cursor, SemanticNode::Empty));
     }
 }

--- a/dexdec/src/ir/structure/types.rs
+++ b/dexdec/src/ir/structure/types.rs
@@ -101,6 +101,12 @@ pub enum StructureError {
         stage: &'static str,
         label: SemanticLabel,
     },
+    SemanticItemLimit {
+        region: RegionId,
+        stage: &'static str,
+        items: usize,
+        limit: usize,
+    },
 }
 
 impl fmt::Display for StructureError {
@@ -257,6 +263,15 @@ impl fmt::Display for StructureError {
                     label.region, label.block
                 )
             }
+            Self::SemanticItemLimit {
+                region,
+                stage,
+                items,
+                limit,
+            } => write!(
+                f,
+                "semantic structure for {region} has {items} nodes and operations after {stage}, above the {limit} item safety limit"
+            ),
         }
     }
 }

--- a/dexdec/src/language/java/ast.rs
+++ b/dexdec/src/language/java/ast.rs
@@ -15,22 +15,30 @@ pub enum JavaPrimitiveType {
 pub struct JavaIdentifier(String);
 
 impl JavaIdentifier {
+    const MAX_BYTES: usize = 200;
+
     pub fn from_dex(value: &str) -> Self {
         if Self::is_source_identifier(value)
             && !Self::is_reserved(value)
             && !value.starts_with("$dex$")
         {
-            return Self(value.to_string());
+            return Self(Self::bounded(value.to_string(), value));
         }
         let mut encoded = String::from("$dex$");
         if value.is_empty() {
             encoded.push_str("empty");
         } else {
             for character in value.chars() {
-                encoded.push_str(&format!("{:X}_", character as u32));
+                if character == '$' {
+                    encoded.push_str("$$");
+                } else if character == '_' || character.is_alphanumeric() {
+                    encoded.push(character);
+                } else {
+                    encoded.push_str(&format!("$u{:X}$", character as u32));
+                }
             }
         }
-        Self(encoded)
+        Self(Self::bounded(encoded, value))
     }
 
     pub fn from_hint(value: &str) -> Self {
@@ -45,6 +53,28 @@ impl JavaIdentifier {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    fn bounded(candidate: String, original: &str) -> String {
+        if candidate.len() <= Self::MAX_BYTES {
+            return candidate;
+        }
+        // FNV-1a keeps the on-disk spelling deterministic while making a
+        // collision between truncated identifiers negligibly likely.
+        let hash = original
+            .as_bytes()
+            .iter()
+            .fold(0xcbf29ce484222325_u64, |hash, byte| {
+                (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+            });
+        let suffix = format!("${hash:016X}");
+        let marker = "$dex$long$";
+        let budget = Self::MAX_BYTES - marker.len() - suffix.len();
+        let mut end = budget.min(candidate.len());
+        while !candidate.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{marker}{}{suffix}", &candidate[..end])
     }
 
     fn is_reserved(value: &str) -> bool {
@@ -860,5 +890,34 @@ pub enum JavaStmt {
 #[derive(Debug, Clone, PartialEq)]
 pub struct JavaMethodBody {
     pub root: JavaStmt,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JavaIdentifier;
+
+    #[test]
+    fn invalid_dex_identifiers_use_compact_reversible_escapes() {
+        assert_eq!(
+            JavaIdentifier::from_dex("measure-3").as_str(),
+            "$dex$measure$u2D$3"
+        );
+        assert_ne!(
+            JavaIdentifier::from_dex("measure-3"),
+            JavaIdentifier::from_dex("measure$u2D$3")
+        );
+    }
+
+    #[test]
+    fn long_dex_identifiers_are_bounded_and_distinct() {
+        let first = format!("{}-first", "LongName".repeat(40));
+        let second = format!("{}-second", "LongName".repeat(40));
+        let first = JavaIdentifier::from_dex(&first);
+        let second = JavaIdentifier::from_dex(&second);
+
+        assert!(first.as_str().len() <= JavaIdentifier::MAX_BYTES);
+        assert!(first.as_str().starts_with("$dex$long$"));
+        assert_ne!(first, second);
+    }
 }
 use crate::ir::Utf16String;

--- a/dexdec/src/language/java/emit.rs
+++ b/dexdec/src/language/java/emit.rs
@@ -8,7 +8,7 @@ use super::literals::JavaLiterals;
 use super::unit::{
     JavaAnnotation, JavaAnnotationValue, JavaAnonymousClassBody, JavaCompilationUnit,
     JavaFieldDeclaration, JavaMethodDeclaration, JavaMethodDeclarationKind, JavaModifier,
-    JavaTypeDeclaration,
+    JavaTypeDeclaration, JavaTypeDeclarationKind,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -257,6 +257,16 @@ impl JavaPrinter {
             }
         }
         if !declaration.enum_constants.is_empty() {
+            writeln!(output, ";")?;
+            wrote_member = true;
+        } else if declaration.kind == JavaTypeDeclarationKind::Enum
+            && (!declaration.fields.is_empty()
+                || !declaration.methods.is_empty()
+                || !declaration.nested.is_empty())
+        {
+            // An enum with no recovered constants still needs the separator
+            // before ordinary members.
+            self.indent(output, depth + 1);
             writeln!(output, ";")?;
             wrote_member = true;
         }
@@ -1853,5 +1863,37 @@ mod tests {
             expression,
             "(java.lang.Object) new java.util.ArrayList<java.lang.String>()"
         );
+    }
+
+    #[test]
+    fn empty_enum_constant_list_is_separated_from_members() {
+        fn declaration(kind: JavaTypeDeclarationKind, name: &str) -> JavaTypeDeclaration {
+            JavaTypeDeclaration {
+                annotations: Vec::new(),
+                modifiers: Vec::new(),
+                kind,
+                name: JavaIdentifier::from_dex(name),
+                type_parameters: Vec::new(),
+                extends: None,
+                implements: Vec::new(),
+                enum_constants: Vec::new(),
+                fields: Vec::new(),
+                methods: Vec::new(),
+                nested: Vec::new(),
+            }
+        }
+
+        let mut root = declaration(JavaTypeDeclarationKind::Enum, "State");
+        root.nested
+            .push(declaration(JavaTypeDeclarationKind::Class, "Member"));
+        let source = JavaPrinter::default()
+            .print_compilation_unit(&JavaCompilationUnit {
+                package: None,
+                imports: Vec::new(),
+                declaration: root,
+            })
+            .expect("enum source");
+
+        assert!(source.contains("enum State {\n    ;\n\n    class Member"));
     }
 }


### PR DESCRIPTION
## Summary

This change makes Java decompilation bounded and file-safe on very large Android inputs, and fixes several systematic Java syntax errors exposed by a 50-DEX production APK.

- encode invalid DEX identifiers compactly and cap Java identifier components at 200 bytes with a deterministic 64-bit suffix;
- repair all unique block-label scopes with one analysis and one tree rewrite instead of rescanning once per label;
- cap dense SCC reachability at 64 MiB and use an exact, cached sparse traversal above that threshold;
- bound repeated whole-graph branch/switch pattern searches before using the existing lexical-label fallback;
- stop method-local semantic recovery above 100,000 semantic nodes/operations, producing an explicit method failure stub instead of exhausting the process;
- normalize Kotlin constructor parameter guards, casted/constant capture stores, stable constructor bindings, enum constructor calls, and empty enum member separators into legal Java syntax.

No CI configuration is changed.

## Failures reproduced

The corpus is Doubao 13.9.0 (`com.larus.nova`), containing 50 DEX files, 456,004 class definitions, and 2,589,787 methods with code.

Before these changes, the corpus exposed several independent failure modes:

1. A single invalid Compose-generated name was hex-encoded character-by-character and exceeded the filesystem's 255-byte component limit, aborting a DEX shard after 8,025 of 9,360 classes.
2. `GiftPanelAction` spent minutes in per-label tree rescans, then attempted a dense transitive-closure allocation whose projected size was about 57 GB. After sparse reachability, its 372,875-item semantic tree still drove downstream allocation to a measured 90 GB peak.
3. `LegacyMultimodalDataProcessor$onMultiFileResultSuccess$1` and `ChatControlTrace` each spent more than 10 minutes in repeated branch-pattern searches.
4. Kotlin-generated constructors emitted parameter checks or captured-field stores before `super(...)`, and failed enum recovery emitted an empty constant section without `;` plus explicit `super(name, ordinal)` calls.

## Result

- the previously failing long identifier now produces a 121-byte path component;
- `GiftPanelAction` terminates in 3.1 seconds at about 1.56 GB RSS and isolates only the oversized method behind an explicit failure stub;
- the legacy coroutine completes in 25.97 seconds at about 782 MB RSS;
- `ChatControlTrace` completes in 13.26 seconds at about 611 MB RSS;
- all three representative constructor/enum samples parse with zero Java syntax-tree errors;
- on `classes14.dex`, files with Java syntax errors fell from 1,404/4,371 to 28/4,371 (98.0% reduction) before the final stable-static-binding cleanup.

The sparse reachability path is exact; it changes storage and query strategy, not reachability semantics. The graph-search budget falls back to the existing lexical-label lowering. The semantic item limit is deliberately method-local: a pathological method becomes an explicit stub while the rest of its class and DEX continue.

Java requires `this(...)` or `super(...)` to be the first constructor statement. Kotlin/JVM bytecode can perform parameter checks before that call, so legal Java source cannot preserve that precise exception-order detail without synthesizing helper methods. This patch moves only recognized Kotlin parameter guards and synthetic capture stores; complex side-effecting constructor preludes remain visible as unsupported syntax rather than being guessed.

## Validation

On the clean PR branch:

- `cargo test -p dexdec --lib`: 340 passed before the final static-binding regression was added; the new targeted regression also passes (341 total library tests);
- `cargo test -p dexdec --test integration_test`: 23 passed;
- targeted regressions cover compact/bounded identifiers, batched label repair, sparse-vs-dense reachability equivalence, constructor guard/capture scheduling, stable static-field bindings, and empty enum member separation.

The end-to-end corpus run also includes the separately submitted semantic fixes in #1 and #2 so their synchronized-loop and state-machine regressions remain covered during comparison.
