### PR TITLE
Bound large-APK Java decompilation and emit legal constructor syntax

### DIFF
--- a/dexdec/src/analysis/java_backend/constructor_syntax.rs
+++ b/dexdec/src/analysis/java_backend/constructor_syntax.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::language::java::{
     JavaAssignOp, JavaAstRewriter, JavaBinaryOp, JavaConstructorTarget, JavaExpr, JavaIdentifier,
-    JavaLiteral, JavaMethodDeclarationKind, JavaStmt, JavaType, JavaTypeDeclaration, JavaUnaryOp,
+    JavaLiteral, JavaMethodDeclarationKind, JavaStmt, JavaType, JavaTypeDeclaration,
+    JavaTypeDeclarationKind, JavaUnaryOp,
 };
 
 /// Removes constructor syntax that Java inserts implicitly.
@@ -10,6 +11,7 @@ pub(super) struct ConstructorSyntaxRecovery;
 
 impl ConstructorSyntaxRecovery {
     pub(super) fn apply(declaration: &mut JavaTypeDeclaration) {
+        let is_enum = declaration.kind == JavaTypeDeclarationKind::Enum;
         let final_fields = declaration
             .fields
             .iter()
@@ -31,16 +33,28 @@ impl ConstructorSyntaxRecovery {
             let JavaStmt::Block(statements) = &mut body.root else {
                 continue;
             };
-            ConstructorCapturePrelude::schedule(
-                statements,
-                &constructor
-                    .parameters
-                    .iter()
-                    .map(|parameter| parameter.name.clone())
-                    .collect(),
-                &final_fields,
-            );
+            let parameters = constructor
+                .parameters
+                .iter()
+                .map(|parameter| parameter.name.clone())
+                .collect::<BTreeSet<_>>();
+            let guards = ConstructorParameterGuards::take(statements, &parameters);
+            ConstructorCapturePrelude::schedule(statements, &parameters, &final_fields);
             Self::schedule_arguments(statements);
+            ConstructorParameterGuards::restore(statements, guards);
+            if is_enum {
+                // Java enum constructors invoke java.lang.Enum implicitly and
+                // reject an explicit super(name, ordinal) invocation.
+                statements.retain(|statement| {
+                    !matches!(
+                        statement,
+                        JavaStmt::ConstructorInvocation {
+                            target: JavaConstructorTarget::Super,
+                            ..
+                        }
+                    )
+                });
+            }
             if matches!(
                 statements.first(),
                 Some(JavaStmt::ConstructorInvocation {
@@ -91,6 +105,67 @@ impl ConstructorSyntaxRecovery {
 
 struct ConstructorCapturePrelude;
 
+struct ConstructorParameterGuards;
+
+impl ConstructorParameterGuards {
+    fn take(
+        statements: &mut Vec<JavaStmt>,
+        parameters: &BTreeSet<JavaIdentifier>,
+    ) -> Vec<JavaStmt> {
+        let Some(invocation) = statements
+            .iter()
+            .position(|statement| matches!(statement, JavaStmt::ConstructorInvocation { .. }))
+        else {
+            return Vec::new();
+        };
+        let leading = statements[..invocation]
+            .iter()
+            .take_while(|statement| Self::is_parameter_guard(statement, parameters))
+            .count();
+        statements.drain(..leading).collect()
+    }
+
+    fn restore(statements: &mut Vec<JavaStmt>, guards: Vec<JavaStmt>) {
+        if guards.is_empty() {
+            return;
+        }
+        let Some(0) = statements
+            .iter()
+            .position(|statement| matches!(statement, JavaStmt::ConstructorInvocation { .. }))
+        else {
+            statements.splice(0..0, guards);
+            return;
+        };
+        statements.splice(1..1, guards);
+    }
+
+    fn is_parameter_guard(statement: &JavaStmt, parameters: &BTreeSet<JavaIdentifier>) -> bool {
+        let JavaStmt::Expression(JavaExpr::Call {
+            receiver: None,
+            owner: Some(JavaType::Class(owner)),
+            method,
+            args,
+            ..
+        }) = statement
+        else {
+            return false;
+        };
+        let is_intrinsics = owner
+            .name()
+            .components()
+            .last()
+            .is_some_and(|component| component.as_str() == "Intrinsics");
+        is_intrinsics
+            && matches!(
+                method.as_str(),
+                "checkNotNullParameter" | "checkParameterIsNotNull"
+            )
+            && args
+                .first()
+                .is_some_and(|value| ConstructorCapturePrelude::is_capture_value(value, parameters))
+    }
+}
+
 impl ConstructorCapturePrelude {
     fn schedule(
         statements: &mut Vec<JavaStmt>,
@@ -127,12 +202,18 @@ impl ConstructorCapturePrelude {
                 ..
             } if matches!(owner.as_ref(), JavaExpr::This)
                 && final_fields.contains(field)
-                && match value {
-                    JavaExpr::Name(parameter) => parameters.contains(parameter),
-                    JavaExpr::QualifiedThis(_) => true,
-                    _ => false,
-                }
+                && Self::is_capture_value(value, parameters)
         )
+    }
+
+    fn is_capture_value(value: &JavaExpr, parameters: &BTreeSet<JavaIdentifier>) -> bool {
+        match value {
+            JavaExpr::Name(parameter) => parameters.contains(parameter),
+            JavaExpr::QualifiedThis(_) => true,
+            JavaExpr::Literal(_) => true,
+            JavaExpr::Cast { value, .. } => Self::is_capture_value(value, parameters),
+            _ => false,
+        }
     }
 }
 
@@ -367,7 +448,8 @@ impl ConstructorBindings {
             | JavaExpr::Super
             | JavaExpr::Name(_)
             | JavaExpr::Literal(_)
-            | JavaExpr::ClassLiteral(_) => true,
+            | JavaExpr::ClassLiteral(_)
+            | JavaExpr::StaticField { .. } => true,
             JavaExpr::Cast { value, .. } => Self::stable(value),
             _ => false,
         }
@@ -844,5 +926,133 @@ impl ExpressionNames {
             }
         }
         names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{ConstructorCapturePrelude, ConstructorParameterGuards, ConstructorSyntaxRecovery};
+    use crate::language::java::{
+        JavaAssignOp, JavaConstructorTarget, JavaExpr, JavaIdentifier, JavaStmt, JavaType,
+    };
+
+    #[test]
+    fn casted_capture_stores_move_after_the_super_invocation() {
+        let parameter = JavaIdentifier::from_dex("captured");
+        let field = JavaIdentifier::from_dex("field");
+        let constant_field = JavaIdentifier::from_dex("constantField");
+        let mut statements = vec![
+            JavaStmt::Assign {
+                target: JavaExpr::Field {
+                    owner: Box::new(JavaExpr::This),
+                    name: field.clone(),
+                },
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Cast {
+                    ty: JavaType::source_class("java.util.List"),
+                    value: Box::new(JavaExpr::Name(parameter.clone())),
+                },
+            },
+            JavaStmt::Assign {
+                target: JavaExpr::Field {
+                    owner: Box::new(JavaExpr::This),
+                    name: constant_field.clone(),
+                },
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Literal(crate::language::java::JavaLiteral::Integer(0)),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                args: vec![JavaExpr::Literal(
+                    crate::language::java::JavaLiteral::Integer(2),
+                )],
+            },
+        ];
+
+        ConstructorCapturePrelude::schedule(
+            &mut statements,
+            &BTreeSet::from([parameter]),
+            &BTreeSet::from([field, constant_field]),
+        );
+
+        assert!(matches!(
+            statements.first(),
+            Some(JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn kotlin_parameter_guards_move_after_the_super_invocation() {
+        let parameter = JavaIdentifier::from_dex("context");
+        let alias = JavaIdentifier::from_dex("checkedContext");
+        let mut statements = vec![
+            JavaStmt::Expression(JavaExpr::Call {
+                receiver: None,
+                owner: Some(JavaType::source_class("kotlin.jvm.internal.Intrinsics")),
+                type_arguments: Vec::new(),
+                method: JavaIdentifier::from_dex("checkNotNullParameter"),
+                args: vec![
+                    JavaExpr::Name(parameter.clone()),
+                    JavaExpr::Literal(crate::language::java::JavaLiteral::String(
+                        crate::ir::Utf16String::from("context"),
+                    )),
+                ],
+            }),
+            JavaStmt::Variable {
+                ty: JavaType::source_class("android.content.Context"),
+                name: alias.clone(),
+                value: Some(JavaExpr::Name(parameter.clone())),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                args: vec![JavaExpr::Name(alias)],
+            },
+        ];
+
+        let parameters = BTreeSet::from([parameter]);
+        let guards = ConstructorParameterGuards::take(&mut statements, &parameters);
+        ConstructorSyntaxRecovery::schedule_arguments(&mut statements);
+        ConstructorParameterGuards::restore(&mut statements, guards);
+
+        assert!(matches!(
+            statements.first(),
+            Some(JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn static_field_bindings_inline_into_constructor_arguments() {
+        let binding = JavaIdentifier::from_dex("trueValue");
+        let value = JavaExpr::StaticField {
+            owner: JavaType::source_class("java.lang.Boolean"),
+            name: JavaIdentifier::from_dex("TRUE"),
+        };
+        let mut statements = vec![
+            JavaStmt::Variable {
+                ty: JavaType::source_class("java.lang.Boolean"),
+                name: binding.clone(),
+                value: Some(value.clone()),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::Super,
+                args: vec![JavaExpr::Name(binding.clone()), JavaExpr::Name(binding)],
+            },
+        ];
+
+        ConstructorSyntaxRecovery::schedule_arguments(&mut statements);
+
+        assert!(matches!(
+            statements.as_slice(),
+            [JavaStmt::ConstructorInvocation { args, .. }]
+                if args == &vec![value.clone(), value]
+        ));
     }
 }

--- a/dexdec/src/cli/decompile.rs
+++ b/dexdec/src/cli/decompile.rs
@@ -9,7 +9,7 @@ use crate::{ClassSelector, DecompileOptions, Decompiler, MethodRequest, SourceLa
 
 use super::error::{CliError, CliResult};
 use super::model::{DecompileRequest, ExitStatus, LanguageSelection, OutputFormat};
-use super::output::{CliHost, CommandContext};
+use super::output::{prepare_file_path, CliHost, CommandContext};
 use super::resolve::ClassResolver;
 
 #[derive(Debug, Serialize)]
@@ -108,12 +108,27 @@ impl DecompileCommand {
                 Err(error) => return Err(error.into()),
             };
             let output_path = if let Some(directory) = request.output_dir.as_deref() {
-                let path = directory.join(&unit.path);
+                let path = prepare_file_path(&directory.join(&unit.path));
+                match context.host_mut().write(&path, unit.source.as_bytes()) {
+                    Ok(()) => Some(path),
+                    Err(error) if !request.fail_fast => {
+                        // Match JADX `SaveCode.save`: log and continue instead of
+                        // aborting the remaining classes in the shard.
+                        let _ = context
+                            .host_mut()
+                            .note(&format!("Save file error: {error}"));
+                        failures.push(GenerationFailure {
+                            class: class.clone(),
+                            error: error.to_string(),
+                        });
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
+            } else if let Some(path) = request.output_file.as_deref() {
+                let path = prepare_file_path(path);
                 context.host_mut().write(&path, unit.source.as_bytes())?;
                 Some(path)
-            } else if let Some(path) = request.output_file.as_deref() {
-                context.host_mut().write(path, unit.source.as_bytes())?;
-                Some(path.to_path_buf())
             } else {
                 None
             };

--- a/dexdec/src/cli/output.rs
+++ b/dexdec/src/cli/output.rs
@@ -2,7 +2,7 @@
 
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
@@ -10,6 +10,80 @@ use super::error::{CliError, CliResult};
 use super::model::{OutputFormat, OutputOptions};
 
 pub const OUTPUT_SCHEMA: &str = "dexdec.cli/v1";
+
+/// Matches JADX `FileUtils.MAX_FILENAME_LENGTH`.
+const MAX_FILENAME_LENGTH: usize = 128;
+/// Matches JADX `FileUtils.MAX_UNIQUE_ID_LENGTH`.
+const MAX_UNIQUE_ID_LENGTH: usize = 3;
+
+/// Matches JADX `FileUtils.prepareFile`: truncate an oversized final path
+/// component and ensure parent directories exist.
+pub fn prepare_file_path(path: &Path) -> PathBuf {
+    let prepared = cut_file_name(path);
+    if let Some(parent) = prepared
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        let _ = fs::create_dir_all(parent);
+    }
+    prepared
+}
+
+/// Matches JADX `FileUtils.cutFileName`.
+pub fn cut_file_name(path: &Path) -> PathBuf {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return path.to_path_buf();
+    };
+    if name.chars().count() <= MAX_FILENAME_LENGTH {
+        return path.to_path_buf();
+    }
+
+    let unique_id = {
+        let hashed = java_string_hash(name).to_string();
+        if hashed.len() > MAX_UNIQUE_ID_LENGTH {
+            hashed[..MAX_UNIQUE_ID_LENGTH].to_string()
+        } else {
+            hashed
+        }
+    };
+    let chars: Vec<char> = name.chars().collect();
+    let dot_index = chars.iter().position(|character| *character == '.');
+    let length_of_suffix = match dot_index {
+        Some(index) => chars.len() - index,
+        // JADX uses `name.indexOf('.')` which is -1 when missing, then
+        // `name.length() - (-1)`.
+        None => chars.len() + 1,
+    };
+    let cut_at = MAX_FILENAME_LENGTH
+        .saturating_sub(length_of_suffix)
+        .saturating_sub(unique_id.len())
+        .saturating_sub(1);
+    let truncated = if cut_at == 0 {
+        chars
+            .iter()
+            .take(MAX_FILENAME_LENGTH.saturating_sub(1))
+            .collect::<String>()
+    } else {
+        let prefix: String = chars.iter().take(cut_at).collect();
+        let suffix: String = match dot_index {
+            Some(index) => chars[index..].iter().collect(),
+            None => String::new(),
+        };
+        format!("{prefix}{unique_id}{suffix}")
+    };
+    match path.parent() {
+        Some(parent) => parent.join(truncated),
+        None => PathBuf::from(truncated),
+    }
+}
+
+fn java_string_hash(value: &str) -> i32 {
+    let mut hash: i32 = 0;
+    for unit in value.encode_utf16() {
+        hash = hash.wrapping_mul(31).wrapping_add(i32::from(unit));
+    }
+    hash
+}
 
 pub trait TextOutput {
     fn emit(&mut self, text: &str) -> CliResult<()>;
@@ -19,7 +93,8 @@ pub trait TextOutput {
     fn emit_or_write(&mut self, path: Option<&Path>, text: &str) -> CliResult<()> {
         match path {
             Some(path) => {
-                self.write_file(path, text)?;
+                let path = prepare_file_path(path);
+                self.write_file(&path, text)?;
                 self.note(&format!("output={}", path.display()))
             }
             None => self.emit(text),
@@ -57,13 +132,8 @@ impl TextOutput for ConsoleHost {
     }
 
     fn write_file(&mut self, path: &Path, text: &str) -> CliResult<()> {
-        if let Some(parent) = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(path, text)?;
+        let path = prepare_file_path(path);
+        fs::write(&path, text)?;
         Ok(())
     }
 
@@ -88,13 +158,8 @@ impl FileSystem for ConsoleHost {
     }
 
     fn write(&mut self, path: &Path, contents: impl AsRef<[u8]>) -> CliResult<()> {
-        if let Some(parent) = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(path, contents)?;
+        let path = prepare_file_path(path);
+        fs::write(&path, contents)?;
         Ok(())
     }
 
@@ -224,4 +289,31 @@ pub fn render_error(format: OutputFormat, pretty: bool, error: &CliError) -> Str
     };
     encoded.push('\n');
     encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cut_file_name, java_string_hash, MAX_FILENAME_LENGTH};
+    use std::path::Path;
+
+    #[test]
+    fn cut_file_name_matches_jadx_hash_truncation() {
+        let long = format!("{}{}", "LongName".repeat(30), ".java");
+        assert!(long.chars().count() > MAX_FILENAME_LENGTH);
+        let cut = cut_file_name(Path::new(&format!("pkg/{long}")));
+        let name = cut.file_name().unwrap().to_str().unwrap();
+        assert!(name.chars().count() <= MAX_FILENAME_LENGTH);
+        assert!(name.ends_with(".java"));
+        let unique = java_string_hash(&long).to_string();
+        let unique = &unique[..unique.len().min(3)];
+        assert!(name.contains(unique), "{name} should contain {unique}");
+    }
+
+    #[test]
+    fn short_file_names_are_unchanged() {
+        assert_eq!(
+            cut_file_name(Path::new("com/example/App.java")),
+            Path::new("com/example/App.java")
+        );
+    }
 }

--- a/dexdec/src/ir/analysis/semantic_flow.rs
+++ b/dexdec/src/ir/analysis/semantic_flow.rs
@@ -5,6 +5,7 @@
 //! one original CFG block.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::{Arc, Mutex};
 
 use crate::ir::{
     RegionId, SemanticExpression, SemanticLabel, SemanticLeave, SemanticLeaveKind,
@@ -49,7 +50,28 @@ pub struct SemanticFlowGraph {
 #[derive(Debug, Clone)]
 pub struct SemanticReachability {
     components: BTreeMap<SemanticFlowPoint, usize>,
-    reachable: Vec<DefinitionSet>,
+    store: ReachabilityStore,
+}
+
+#[derive(Debug, Clone)]
+enum ReachabilityStore {
+    Dense(Vec<DefinitionSet>),
+    Sparse(Arc<SparseReachability>),
+}
+
+#[derive(Debug)]
+struct SparseReachability {
+    successors: Vec<Vec<usize>>,
+    predecessors: Vec<Vec<usize>>,
+    topological_positions: Vec<usize>,
+    forward: Mutex<ReachabilityCache>,
+    backward: Mutex<ReachabilityCache>,
+}
+
+#[derive(Debug, Default)]
+struct ReachabilityCache {
+    order: VecDeque<usize>,
+    rows: BTreeMap<usize, Arc<DefinitionSet>>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -198,6 +220,11 @@ impl SemanticReachingValues {
 
 impl SemanticReachability {
     fn analyze(graph: &SemanticFlowGraph) -> Self {
+        const MAX_DENSE_BYTES: usize = 64 * 1024 * 1024;
+        Self::analyze_with_dense_limit(graph, MAX_DENSE_BYTES)
+    }
+
+    fn analyze_with_dense_limit(graph: &SemanticFlowGraph, max_dense_bytes: usize) -> Self {
         let points = graph
             .predecessors
             .keys()
@@ -292,23 +319,49 @@ impl SemanticReachability {
         }
         debug_assert_eq!(topological.len(), component_count);
 
-        let mut reachable = (0..component_count)
-            .map(|component| {
-                let mut set = DefinitionSet::new(component_count);
-                set.insert(component);
-                set
-            })
-            .collect::<Vec<_>>();
-        for component in topological.into_iter().rev() {
-            for successor in &successors[component] {
-                let successor_reachability = reachable[*successor].clone();
-                reachable[component].union_with(&successor_reachability);
+        let words_per_row = component_count.div_ceil(u64::BITS as usize);
+        let dense_bytes = component_count
+            .saturating_mul(words_per_row)
+            .saturating_mul(std::mem::size_of::<u64>());
+        let store = if dense_bytes <= max_dense_bytes {
+            let mut reachable = (0..component_count)
+                .map(|component| {
+                    let mut set = DefinitionSet::new(component_count);
+                    set.insert(component);
+                    set
+                })
+                .collect::<Vec<_>>();
+            for component in topological.into_iter().rev() {
+                for successor in &successors[component] {
+                    let successor_reachability = reachable[*successor].clone();
+                    reachable[component].union_with(&successor_reachability);
+                }
             }
-        }
-        Self {
-            components,
-            reachable,
-        }
+            ReachabilityStore::Dense(reachable)
+        } else {
+            let successors = successors
+                .into_iter()
+                .map(|targets| targets.into_iter().collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+            let mut predecessors = vec![Vec::new(); component_count];
+            for (source, targets) in successors.iter().enumerate() {
+                for target in targets {
+                    predecessors[*target].push(source);
+                }
+            }
+            let mut topological_positions = vec![0; component_count];
+            for (position, component) in topological.into_iter().enumerate() {
+                topological_positions[component] = position;
+            }
+            ReachabilityStore::Sparse(Arc::new(SparseReachability {
+                successors,
+                predecessors,
+                topological_positions,
+                forward: Mutex::new(ReachabilityCache::default()),
+                backward: Mutex::new(ReachabilityCache::default()),
+            }))
+        };
+        Self { components, store }
     }
 
     pub fn reaches(&self, source: SemanticFlowPoint, target: SemanticFlowPoint) -> bool {
@@ -317,7 +370,10 @@ impl SemanticReachability {
         else {
             return false;
         };
-        self.reachable[*source].contains(*target)
+        match &self.store {
+            ReachabilityStore::Dense(reachable) => reachable[*source].contains(*target),
+            ReachabilityStore::Sparse(reachable) => reachable.reaches(*source, *target),
+        }
     }
 
     pub fn reaches_any_between(
@@ -326,9 +382,90 @@ impl SemanticReachability {
         target: SemanticFlowPoint,
         candidates: &BTreeSet<SemanticFlowPoint>,
     ) -> bool {
-        candidates
-            .iter()
-            .any(|candidate| self.reaches(source, *candidate) && self.reaches(*candidate, target))
+        match &self.store {
+            ReachabilityStore::Dense(_) => candidates.iter().any(|candidate| {
+                self.reaches(source, *candidate) && self.reaches(*candidate, target)
+            }),
+            ReachabilityStore::Sparse(reachable) => {
+                let (Some(source), Some(target)) =
+                    (self.components.get(&source), self.components.get(&target))
+                else {
+                    return false;
+                };
+                let from_source = reachable.forward_row(*source);
+                let to_target = reachable.backward_row(*target);
+                candidates.iter().any(|candidate| {
+                    self.components.get(candidate).is_some_and(|candidate| {
+                        from_source.contains(*candidate) && to_target.contains(*candidate)
+                    })
+                })
+            }
+        }
+    }
+}
+
+impl SparseReachability {
+    const MAX_CACHED_ROWS: usize = 32;
+
+    fn reaches(&self, source: usize, target: usize) -> bool {
+        if source == target {
+            return true;
+        }
+        if self.topological_positions[source] >= self.topological_positions[target] {
+            return false;
+        }
+        self.forward_row(source).contains(target)
+    }
+
+    fn forward_row(&self, source: usize) -> Arc<DefinitionSet> {
+        Self::row(&self.forward, &self.successors, source)
+    }
+
+    fn backward_row(&self, target: usize) -> Arc<DefinitionSet> {
+        Self::row(&self.backward, &self.predecessors, target)
+    }
+
+    fn row(
+        cache: &Mutex<ReachabilityCache>,
+        adjacency: &[Vec<usize>],
+        source: usize,
+    ) -> Arc<DefinitionSet> {
+        if let Some(row) = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .rows
+            .get(&source)
+            .cloned()
+        {
+            return row;
+        }
+
+        let mut row = DefinitionSet::new(adjacency.len());
+        let mut pending = vec![source];
+        while let Some(component) = pending.pop() {
+            if row.contains(component) {
+                continue;
+            }
+            row.insert(component);
+            pending.extend(adjacency[component].iter().copied());
+        }
+        let row = Arc::new(row);
+
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(existing) = cache.rows.get(&source) {
+            return existing.clone();
+        }
+        while cache.rows.len() >= Self::MAX_CACHED_ROWS {
+            let Some(evicted) = cache.order.pop_front() else {
+                break;
+            };
+            cache.rows.remove(&evicted);
+        }
+        cache.order.push_back(source);
+        cache.rows.insert(source, row.clone());
+        row
     }
 }
 
@@ -1692,6 +1829,47 @@ mod tests {
         };
 
         assert!(!graph.must_reach(source, target));
+    }
+
+    #[test]
+    fn sparse_reachability_matches_dense_reachability() {
+        let points = (0..7).map(point).collect::<Vec<_>>();
+        let mut graph = SemanticFlowGraph {
+            complete: true,
+            ..SemanticFlowGraph::default()
+        };
+        for (source, target) in [(0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (4, 3), (4, 5)] {
+            graph
+                .successors
+                .entry(points[source])
+                .or_default()
+                .push(points[target]);
+            graph
+                .predecessors
+                .entry(points[target])
+                .or_default()
+                .push((points[source], SemanticFlowEdgeKind::Normal));
+        }
+        graph.entries.insert(points[0]);
+
+        let dense = SemanticReachability::analyze_with_dense_limit(&graph, usize::MAX);
+        let sparse = SemanticReachability::analyze_with_dense_limit(&graph, 0);
+        assert!(matches!(sparse.store, ReachabilityStore::Sparse(_)));
+        for source in &points {
+            for target in &points {
+                assert_eq!(
+                    sparse.reaches(*source, *target),
+                    dense.reaches(*source, *target),
+                    "reachability mismatch from {source:?} to {target:?}"
+                );
+            }
+        }
+
+        let candidates = BTreeSet::from([points[1], points[2], points[6]]);
+        assert_eq!(
+            sparse.reaches_any_between(points[0], points[5], &candidates),
+            dense.reaches_any_between(points[0], points[5], &candidates)
+        );
     }
 }
 

--- a/dexdec/src/ir/structure/flow_graph.rs
+++ b/dexdec/src/ir/structure/flow_graph.rs
@@ -348,6 +348,7 @@ impl SemanticFlowGraph {
         mut self,
         semantic: &SemanticFactory<'_>,
     ) -> Result<(SemanticNode, u32), StructureError> {
+        let mut pattern_budget = PatternReductionBudget::for_nodes(self.nodes.len());
         loop {
             self.prune();
             FragmentNormalizer::apply(&mut self)?;
@@ -359,7 +360,10 @@ impl SemanticFlowGraph {
                 .find(|component| self.is_cyclic(component))
             else {
                 if semantic.is_switch_region(self.region) {
-                    while let Some(switch) = SwitchRegion::analyze(&self)? {
+                    while pattern_budget.take() {
+                        let Some(switch) = SwitchRegion::analyze(&self)? else {
+                            break;
+                        };
                         self.collapse_switch(switch, semantic)?;
                         self.prune();
                         self.verify_lexical_domains()?;
@@ -368,7 +372,10 @@ impl SemanticFlowGraph {
                 if let Some(body) = self.structure_acyclic(semantic)? {
                     return Ok((body, self.next_id));
                 }
-                while let Some(branch) = BranchRegion::analyze(&self)? {
+                while pattern_budget.take() {
+                    let Some(branch) = BranchRegion::analyze(&self)? else {
+                        break;
+                    };
                     self.collapse_branch(branch, semantic)?;
                     self.prune();
                     self.verify_lexical_domains()?;
@@ -1982,6 +1989,30 @@ impl SwitchRegion {
 /// opcode or source-language shape.
 struct NodeSplittingBudget {
     limit: usize,
+}
+
+/// Bounds repeated whole-graph pattern searches before the equivalent lexical
+/// label fallback is used. Branch-arm discovery can be quadratic in graph size;
+/// without a shared budget, a single generated coroutine can stall an archive
+/// batch for minutes even though label lowering can finish it directly.
+struct PatternReductionBudget {
+    remaining: usize,
+}
+
+impl PatternReductionBudget {
+    fn for_nodes(nodes: usize) -> Self {
+        const WORK_BUDGET: usize = 1_000_000;
+        let nodes = nodes.max(1);
+        Self {
+            remaining: (WORK_BUDGET / nodes / nodes).clamp(4, 64),
+        }
+    }
+
+    fn take(&mut self) -> bool {
+        let available = self.remaining > 0;
+        self.remaining = self.remaining.saturating_sub(1);
+        available
+    }
 }
 
 impl NodeSplittingBudget {

--- a/dexdec/src/ir/structure/region_reducer.rs
+++ b/dexdec/src/ir/structure/region_reducer.rs
@@ -9,7 +9,7 @@ use crate::ir::semantic::SemanticFactory;
 use crate::ir::{
     BlockId, RegionGraph, RegionId, RegionKind, SemanticBlock, SemanticCatch, SemanticFinally,
     SemanticFoldError, SemanticFolder, SemanticLeave, SemanticLeaveKind, SemanticNode,
-    StructuredRegion, CFG,
+    SemanticOperation, SemanticVisitor, StructuredRegion, CFG,
 };
 
 use super::{
@@ -143,12 +143,35 @@ impl<'a> RegionReducer<'a> {
             });
         }
         Self::verify_root_labels("contracted", &root.body)?;
+        Self::verify_node_limit(root_region, "contraction", &root.body)?;
         let body = ExceptionEnvelopeCanonicalizer::new(self.cfg, self.regions).apply(root.body)?;
         Self::verify_root_labels("exception-canonicalized", &body)?;
+        Self::verify_node_limit(root_region, "exception canonicalization", &body)?;
         let mut body = LexicalLabels::uniquify(body).map_err(StructureError::from)?;
         Self::verify_root_labels("label-uniquified", &body)?;
+        Self::verify_node_limit(root_region, "label repair", &body)?;
         SemanticCleanupResolver::apply(self.regions, &mut body);
         Ok(body)
+    }
+
+    fn verify_node_limit(
+        region: RegionId,
+        stage: &'static str,
+        body: &SemanticNode,
+    ) -> Result<(), StructureError> {
+        const MAX_SEMANTIC_ITEMS: usize = 100_000;
+        let mut count = SemanticComplexity::default();
+        count.visit_node(body);
+        if count.items > MAX_SEMANTIC_ITEMS {
+            Err(StructureError::SemanticItemLimit {
+                region,
+                stage,
+                items: count.items,
+                limit: MAX_SEMANTIC_ITEMS,
+            })
+        } else {
+            Ok(())
+        }
     }
 
     fn verify_root_labels(stage: &'static str, body: &SemanticNode) -> Result<(), StructureError> {
@@ -462,6 +485,21 @@ impl<'a> RegionReducer<'a> {
             }),
             continuation,
         ])
+    }
+}
+
+#[derive(Default)]
+struct SemanticComplexity {
+    items: usize,
+}
+
+impl SemanticVisitor for SemanticComplexity {
+    fn enter_node(&mut self, _node: &SemanticNode) {
+        self.items = self.items.saturating_add(1);
+    }
+
+    fn enter_operation(&mut self, _operation: &SemanticOperation) {
+        self.items = self.items.saturating_add(1);
     }
 }
 

--- a/dexdec/src/ir/structure/region_reducer/labels.rs
+++ b/dexdec/src/ir/structure/region_reducer/labels.rs
@@ -26,7 +26,7 @@ impl LexicalLabels {
             .iter()
             .filter_map(|(label, count)| (*count > 1).then_some(*label))
             .collect::<BTreeSet<_>>();
-        let mut root = if duplicates.is_empty() {
+        let root = if duplicates.is_empty() {
             root
         } else {
             Self {
@@ -44,12 +44,12 @@ impl LexicalLabels {
 
         let mut unique = LabelDefinitions::default();
         unique.visit_node(&root);
-        for label in unique.counts.into_iter().filter_map(|(label, count)| {
-            (count == 1 && label.kind == SemanticLabelKind::Block).then_some(label)
-        }) {
-            root = LexicalLabelScope::repair(root, label)?;
-        }
-        Ok(root)
+        LexicalLabelScopes::repair(
+            root,
+            unique.counts.into_iter().filter_map(|(label, count)| {
+                (count == 1 && label.kind == SemanticLabelKind::Block).then_some(label)
+            }),
+        )
     }
 
     pub(super) fn escaped_loop(root: &SemanticNode) -> Option<SemanticLabel> {
@@ -150,36 +150,57 @@ impl SemanticVisitor for LoopLabelScopes {
 
 /// Places a block-label binding at the lowest semantic-tree ancestor that
 /// contains both its definition and every transfer targeting it.
+#[derive(Default)]
 struct LexicalLabelScope {
-    label: SemanticLabel,
     definition: Option<Vec<usize>>,
     references: Vec<Vec<usize>>,
 }
 
-impl LexicalLabelScope {
-    fn repair(root: SemanticNode, label: SemanticLabel) -> Result<SemanticNode, SemanticFoldError> {
-        let mut scope = Self {
-            label,
-            definition: None,
-            references: Vec::new(),
-        };
-        scope.analyze(&root);
-        let Some(definition) = scope.definition else {
+/// Repairs all block-label scopes with one analysis and one rewrite pass.
+///
+/// Running both passes once per label makes large irreducible methods quadratic
+/// in the number of labels and can effectively stall whole-file decompilation.
+struct LexicalLabelScopes {
+    scopes: BTreeMap<SemanticLabel, LexicalLabelScope>,
+}
+
+impl LexicalLabelScopes {
+    fn repair(
+        root: SemanticNode,
+        labels: impl IntoIterator<Item = SemanticLabel>,
+    ) -> Result<SemanticNode, SemanticFoldError> {
+        let scopes = labels
+            .into_iter()
+            .map(|label| (label, LexicalLabelScope::default()))
+            .collect::<BTreeMap<_, _>>();
+        if scopes.is_empty() {
             return Ok(root);
-        };
-        let mut binding = definition.clone();
-        for reference in &scope.references {
-            let common = binding
-                .iter()
-                .zip(reference)
-                .take_while(|(left, right)| left == right)
-                .count();
-            binding.truncate(common);
         }
-        LabelScopeRewrite {
-            label,
-            definition,
-            binding,
+        let mut scopes = Self { scopes };
+        scopes.analyze(&root);
+
+        let mut definitions = BTreeMap::new();
+        let mut bindings = BTreeMap::<Vec<usize>, Vec<SemanticLabel>>::new();
+        for (label, scope) in scopes.scopes {
+            let Some(definition) = scope.definition else {
+                continue;
+            };
+            let mut binding = definition.clone();
+            for reference in &scope.references {
+                let common = binding
+                    .iter()
+                    .zip(reference)
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                binding.truncate(common);
+            }
+            definitions.insert(definition, label);
+            bindings.entry(binding).or_default().push(label);
+        }
+
+        LabelScopesRewrite {
+            definitions,
+            bindings,
             stack: Vec::new(),
         }
         .fold_node(root)
@@ -189,18 +210,23 @@ impl LexicalLabelScope {
         let mut pending = vec![(root, Vec::new())];
         while let Some((node, path)) = pending.pop() {
             match node {
-                SemanticNode::Label { label, .. } if *label == self.label => {
-                    self.definition = Some(path.clone());
+                SemanticNode::Label { label, .. } => {
+                    if let Some(scope) = self.scopes.get_mut(label) {
+                        scope.definition = Some(path.clone());
+                    }
                 }
-                SemanticNode::Leave(leave)
-                    if matches!(
-                        &leave.kind,
+                SemanticNode::Leave(leave) => {
+                    let label = match &leave.kind {
                         SemanticLeaveKind::BreakLabel(label)
-                            | SemanticLeaveKind::ContinueLabel(label)
-                            if *label == self.label
-                    ) =>
-                {
-                    self.references.push(path.clone());
+                        | SemanticLeaveKind::ContinueLabel(label) => label,
+                        _ => {
+                            Self::push_children(node, &path, &mut pending);
+                            continue;
+                        }
+                    };
+                    if let Some(scope) = self.scopes.get_mut(label) {
+                        scope.references.push(path.clone());
+                    }
                 }
                 _ => {}
             }
@@ -266,10 +292,9 @@ impl LexicalLabelScope {
     }
 }
 
-struct LabelScopeRewrite {
-    label: SemanticLabel,
-    definition: Vec<usize>,
-    binding: Vec<usize>,
+struct LabelScopesRewrite {
+    definitions: BTreeMap<Vec<usize>, SemanticLabel>,
+    bindings: BTreeMap<Vec<usize>, Vec<SemanticLabel>>,
     stack: Vec<PathFrame>,
 }
 
@@ -278,7 +303,7 @@ struct PathFrame {
     next_child: usize,
 }
 
-impl SemanticFolder for LabelScopeRewrite {
+impl SemanticFolder for LabelScopesRewrite {
     type Error = SemanticFoldError;
 
     fn enter_node(&mut self, _node: &SemanticNode) {
@@ -304,22 +329,25 @@ impl SemanticFolder for LabelScopeRewrite {
             .pop()
             .ok_or(SemanticFoldError::MalformedWorkStack)?
             .path;
-        let node = if path == self.definition {
+        let mut node = if let Some(definition) = self.definitions.get(&path) {
             match node {
-                SemanticNode::Label { label, body } if label == self.label => *body,
+                SemanticNode::Label { label, body } if label == *definition => *body,
                 node => node,
             }
         } else {
             node
         };
-        Ok(if path == self.binding {
-            SemanticNode::Label {
-                label: self.label,
-                body: Box::new(node),
+        if let Some(bindings) = self.bindings.get(&path) {
+            // Match the previous deterministic per-label behavior: lower
+            // labels become outer scopes when several labels share one LCA.
+            for label in bindings.iter().rev() {
+                node = SemanticNode::Label {
+                    label: *label,
+                    body: Box::new(node),
+                };
             }
-        } else {
-            node
-        })
+        }
+        Ok(node)
     }
 }
 
@@ -385,5 +413,75 @@ impl SemanticFolder for LabelReferenceRewrite {
             _ => {}
         }
         Ok(node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LexicalLabels;
+    use crate::ir::{
+        BlockId, RegionId, SemanticLabel, SemanticLeave, SemanticLeaveKind, SemanticNode,
+    };
+
+    #[test]
+    fn block_label_scopes_are_repaired_in_one_tree_rewrite() {
+        let region = RegionId::new(0);
+        let label = SemanticLabel::block(region, BlockId::new(1));
+        let root = SemanticNode::Sequence(vec![
+            SemanticNode::Leave(SemanticLeave {
+                site: None,
+                condition: None,
+                kind: SemanticLeaveKind::BreakLabel(label),
+                edge: None,
+                origin: None,
+                source: region,
+                destination: region,
+                target: region,
+                cleanup: Vec::new(),
+            }),
+            SemanticNode::Label {
+                label,
+                body: Box::new(SemanticNode::Empty),
+            },
+        ]);
+
+        let repaired = LexicalLabels::uniquify(root).expect("label scope repair");
+
+        let SemanticNode::Label {
+            label: repaired_label,
+            body,
+        } = repaired
+        else {
+            panic!("shared scope must bind the label at the sequence root");
+        };
+        assert_eq!(repaired_label, label);
+        assert!(matches!(
+            *body,
+            SemanticNode::Sequence(ref children)
+                if matches!(children.get(1), Some(SemanticNode::Empty))
+        ));
+    }
+
+    #[test]
+    fn many_unique_block_labels_do_not_require_per_label_tree_rewrites() {
+        let region = RegionId::new(0);
+        let mut root = SemanticNode::Empty;
+        for block in 1..=1_000 {
+            root = SemanticNode::Label {
+                label: SemanticLabel::block(region, BlockId::new(block)),
+                body: Box::new(root),
+            };
+        }
+
+        let repaired = LexicalLabels::uniquify(root).expect("bulk label scope repair");
+
+        let mut labels = 0;
+        let mut cursor = &repaired;
+        while let SemanticNode::Label { body, .. } = cursor {
+            labels += 1;
+            cursor = body;
+        }
+        assert_eq!(labels, 1_000);
+        assert!(matches!(cursor, SemanticNode::Empty));
     }
 }

--- a/dexdec/src/ir/structure/types.rs
+++ b/dexdec/src/ir/structure/types.rs
@@ -101,6 +101,12 @@ pub enum StructureError {
         stage: &'static str,
         label: SemanticLabel,
     },
+    SemanticItemLimit {
+        region: RegionId,
+        stage: &'static str,
+        items: usize,
+        limit: usize,
+    },
 }
 
 impl fmt::Display for StructureError {
@@ -257,6 +263,15 @@ impl fmt::Display for StructureError {
                     label.region, label.block
                 )
             }
+            Self::SemanticItemLimit {
+                region,
+                stage,
+                items,
+                limit,
+            } => write!(
+                f,
+                "semantic structure for {region} has {items} nodes and operations after {stage}, above the {limit} item safety limit"
+            ),
         }
     }
 }

--- a/dexdec/src/language/java/ast.rs
+++ b/dexdec/src/language/java/ast.rs
@@ -15,36 +15,99 @@ pub enum JavaPrimitiveType {
 pub struct JavaIdentifier(String);
 
 impl JavaIdentifier {
+    /// Sanitize a DEX name the way JADX's `NameMapper` / rename checks do for
+    /// fields and methods: keep valid printable identifiers, otherwise drop
+    /// illegal characters instead of hex-escaping them.
     pub fn from_dex(value: &str) -> Self {
-        if Self::is_source_identifier(value)
-            && !Self::is_reserved(value)
-            && !value.starts_with("$dex$")
-        {
+        if Self::is_valid_and_printable(value) {
             return Self(value.to_string());
         }
-        let mut encoded = String::from("$dex$");
-        if value.is_empty() {
-            encoded.push_str("empty");
-        } else {
-            for character in value.chars() {
-                encoded.push_str(&format!("{:X}_", character as u32));
-            }
+        let clean = Self::remove_invalid_chars(value, "C");
+        if clean.is_empty() {
+            return Self(Self::alias_fallback(value));
         }
-        Self(encoded)
+        if !Self::is_valid_identifier(&clean) {
+            return Self(format!("C{clean}"));
+        }
+        Self(clean)
     }
 
     pub fn from_hint(value: &str) -> Self {
-        if Self::is_source_identifier(value) {
-            if Self::is_reserved(value) {
-                return Self(format!("{value}Value"));
-            }
+        if Self::is_valid_and_printable(value) {
             return Self(value.to_string());
+        }
+        if Self::is_reserved(value) && Self::is_all_chars_printable(value) {
+            return Self(format!("{value}Value"));
         }
         Self::from_dex(value)
     }
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    fn alias_fallback(original: &str) -> String {
+        // JADX falls back to `IAliasProvider` indexes. Without a global counter,
+        // mirror `DeobfAliasProvider.prepareNamePart` for over-long names:
+        // `x` + hex(Java String.hashCode()).
+        format!("C{:x}", java_string_hash(original) as u32)
+    }
+
+    fn remove_invalid_chars_middle(name: &str) -> String {
+        if Self::is_valid_identifier(name) && Self::is_all_chars_printable(name) {
+            return name.to_string();
+        }
+        name.chars()
+            .filter(|&character| {
+                Self::is_printable_ascii(character) && Self::is_java_identifier_part(character)
+            })
+            .collect()
+    }
+
+    fn remove_invalid_chars(name: &str, prefix: &str) -> String {
+        let result = Self::remove_invalid_chars_middle(name);
+        if result.is_empty() {
+            return result;
+        }
+        let first = result.chars().next().expect("non-empty");
+        if !Self::is_java_identifier_start(first) {
+            return format!("{prefix}{result}");
+        }
+        result
+    }
+
+    fn is_printable_ascii(character: char) -> bool {
+        let code = character as u32;
+        (32..=126).contains(&code)
+    }
+
+    fn is_all_chars_printable(value: &str) -> bool {
+        value.chars().all(Self::is_printable_ascii)
+    }
+
+    fn is_java_identifier_start(character: char) -> bool {
+        // ASCII subset of `Character.isJavaIdentifierStart` under JADX's
+        // printable-ASCII rename filter.
+        character.is_ascii_alphabetic() || character == '_' || character == '$'
+    }
+
+    fn is_java_identifier_part(character: char) -> bool {
+        Self::is_java_identifier_start(character) || character.is_ascii_digit()
+    }
+
+    fn is_valid_and_printable(value: &str) -> bool {
+        Self::is_valid_identifier(value) && Self::is_all_chars_printable(value)
+    }
+
+    fn is_valid_identifier(value: &str) -> bool {
+        if value.is_empty() || Self::is_reserved(value) {
+            return false;
+        }
+        let mut characters = value.chars();
+        let Some(first) = characters.next() else {
+            return false;
+        };
+        Self::is_java_identifier_start(first) && characters.all(Self::is_java_identifier_part)
     }
 
     fn is_reserved(value: &str) -> bool {
@@ -106,17 +169,15 @@ impl JavaIdentifier {
                 | "_"
         )
     }
+}
 
-    fn is_source_identifier(value: &str) -> bool {
-        let mut characters = value.chars();
-        let Some(first) = characters.next() else {
-            return false;
-        };
-        (first == '_' || first == '$' || first.is_alphabetic())
-            && characters.all(|character| {
-                character == '_' || character == '$' || character.is_alphanumeric()
-            })
+/// Java `String.hashCode()` over UTF-16 code units.
+fn java_string_hash(value: &str) -> i32 {
+    let mut hash: i32 = 0;
+    for unit in value.encode_utf16() {
+        hash = hash.wrapping_mul(31).wrapping_add(i32::from(unit));
     }
+    hash
 }
 
 impl std::fmt::Display for JavaIdentifier {
@@ -860,5 +921,29 @@ pub enum JavaStmt {
 #[derive(Debug, Clone, PartialEq)]
 pub struct JavaMethodBody {
     pub root: JavaStmt,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JavaIdentifier;
+
+    #[test]
+    fn invalid_dex_identifiers_drop_illegal_characters_like_jadx() {
+        assert_eq!(JavaIdentifier::from_dex("measure-3").as_str(), "measure3");
+        assert_eq!(JavaIdentifier::from_dex("do").as_str(), "Cdo");
+        assert_eq!(JavaIdentifier::from_dex("1Foo").as_str(), "C1Foo");
+        assert_eq!(
+            JavaIdentifier::from_dex("$$$reportNull$$$0").as_str(),
+            "$$$reportNull$$$0"
+        );
+    }
+
+    #[test]
+    fn long_printable_identifiers_are_kept_for_cut_file_name() {
+        let name = "LongName".repeat(40);
+        let identifier = JavaIdentifier::from_dex(&name);
+        assert_eq!(identifier.as_str(), name);
+        assert!(identifier.as_str().len() > 128);
+    }
 }
 use crate::ir::Utf16String;

--- a/dexdec/src/language/java/emit.rs
+++ b/dexdec/src/language/java/emit.rs
@@ -8,7 +8,7 @@ use super::literals::JavaLiterals;
 use super::unit::{
     JavaAnnotation, JavaAnnotationValue, JavaAnonymousClassBody, JavaCompilationUnit,
     JavaFieldDeclaration, JavaMethodDeclaration, JavaMethodDeclarationKind, JavaModifier,
-    JavaTypeDeclaration,
+    JavaTypeDeclaration, JavaTypeDeclarationKind,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -257,6 +257,16 @@ impl JavaPrinter {
             }
         }
         if !declaration.enum_constants.is_empty() {
+            writeln!(output, ";")?;
+            wrote_member = true;
+        } else if declaration.kind == JavaTypeDeclarationKind::Enum
+            && (!declaration.fields.is_empty()
+                || !declaration.methods.is_empty()
+                || !declaration.nested.is_empty())
+        {
+            // An enum with no recovered constants still needs the separator
+            // before ordinary members.
+            self.indent(output, depth + 1);
             writeln!(output, ";")?;
             wrote_member = true;
         }
@@ -1853,5 +1863,37 @@ mod tests {
             expression,
             "(java.lang.Object) new java.util.ArrayList<java.lang.String>()"
         );
+    }
+
+    #[test]
+    fn empty_enum_constant_list_is_separated_from_members() {
+        fn declaration(kind: JavaTypeDeclarationKind, name: &str) -> JavaTypeDeclaration {
+            JavaTypeDeclaration {
+                annotations: Vec::new(),
+                modifiers: Vec::new(),
+                kind,
+                name: JavaIdentifier::from_dex(name),
+                type_parameters: Vec::new(),
+                extends: None,
+                implements: Vec::new(),
+                enum_constants: Vec::new(),
+                fields: Vec::new(),
+                methods: Vec::new(),
+                nested: Vec::new(),
+            }
+        }
+
+        let mut root = declaration(JavaTypeDeclarationKind::Enum, "State");
+        root.nested
+            .push(declaration(JavaTypeDeclarationKind::Class, "Member"));
+        let source = JavaPrinter::default()
+            .print_compilation_unit(&JavaCompilationUnit {
+                package: None,
+                imports: Vec::new(),
+                declaration: root,
+            })
+            .expect("enum source");
+
+        assert!(source.contains("enum State {\n    ;\n\n    class Member"));
     }
 }

--- a/dexdec/tests/cli_args_test.rs
+++ b/dexdec/tests/cli_args_test.rs
@@ -1,17 +1,17 @@
 use clap::Parser;
 
-use dexdec::cli::{Cli, Command};
+use dexdec::cli::{Cli, Command, LanguageSelection};
 use dexdec::SourceLanguage;
 
 #[test]
-fn decompile_defaults_to_kotlin() {
+fn decompile_defaults_to_auto_language() {
     let cli = Cli::try_parse_from(["dexdec", "decompile", "classes.dex"]).unwrap();
-    let Command::Decompile(request) = cli.into_command() else {
+    let Command::Decompile(request) = cli.into_invocation().command else {
         panic!("expected decompile command");
     };
 
-    assert_eq!(request.language, SourceLanguage::Kotlin);
-    assert!(request.include_inner);
+    assert_eq!(request.language, LanguageSelection::Auto);
+    assert!(request.include_nested);
 }
 
 #[test]
@@ -22,13 +22,16 @@ fn decompile_accepts_java_without_nested_classes() {
         "classes.dex",
         "--language",
         "java",
-        "--no-inner",
+        "--no-nested",
     ])
     .unwrap();
-    let Command::Decompile(request) = cli.into_command() else {
+    let Command::Decompile(request) = cli.into_invocation().command else {
         panic!("expected decompile command");
     };
 
-    assert_eq!(request.language, SourceLanguage::Java);
-    assert!(!request.include_inner);
+    assert_eq!(
+        request.language,
+        LanguageSelection::Fixed(SourceLanguage::Java)
+    );
+    assert!(!request.include_nested);
 }


### PR DESCRIPTION
## Summary

- Sanitize illegal DEX identifiers the way JADX does (`NameMapper`-style stripping instead of hex escaping), and truncate oversized output file names with JADX `FileUtils.cutFileName` (128-char limit + short `hashCode` suffix) so a single long name cannot abort an entire DEX shard write.
- Repair all unique block-label scopes in one analysis/rewrite pass, cap dense SCC reachability, bound pathological graph searches, and fail only oversized method-local semantic recoveries instead of exhausting process memory.
- Normalize Kotlin constructor parameter guards / capture stores, illegal enum `super(name, ordinal)` calls, and stable static field bindings into legal Java constructor syntax.
- Update `cli_args_test` for the current `into_invocation` / `LanguageSelection` / `include_nested` CLI API so the suite compiles against `main`.

## Motivation

On very large multi-DEX Android inputs, Java decompilation previously hit independent hard failures:

1. Invalid DEX names were hex-encoded character-by-character, inflating path components past the filesystem 255-byte limit and stopping shard output mid-way.
2. Per-label lexical scope repair and dense reachability allocation could stall for minutes or attempt multi-tens-of-GB matrices on irreducible methods.
3. Kotlin-shaped constructor preludes and failed enum recovery emitted Java that does not parse (`super` not first; explicit `Enum` constructor calls; missing enum separators).

This PR keeps recovery exact where possible (sparse reachability is semantically equivalent) and uses method-local failure stubs only above an explicit semantic-size safety limit.

## Cross-check

- Identifier handling follows JADX `NameMapper` + `RenameVisitor` validation (drop illegal/non-printable chars; keep valid `$` names; prefix `C` when needed) and JADX `FileUtils.prepareFile` / `cutFileName` at write time.
- Save failures are non-fatal when `--fail-fast` is off, matching JADX `SaveCode` logging behavior for a single class write error.
- Constructor/enum legalization is conservative: only recognized Kotlin parameter guards and synthetic capture stores are moved; complex side-effecting preludes are left visible rather than guessed.

## Test plan

- [x] `cargo test -p dexdec --lib` (343 passed)
- [x] `cargo test -p dexdec --test integration_test` (25 passed)
- [x] `cargo test -p dexdec --test expected_test` (4 passed)
- [x] `cargo test -p dexdec --test cli_args_test` (2 passed)
- [x] `cargo test -p dexdec --test constructor_delegate_test`
- [x] `cargo test -p dexdec --test override_analysis_cache_test`
- [x] `cargo test -p dexdec --test platform_generic_contract_test`
- [x] `cargo test -p dexdec --test platform_symbols_test`
- [x] `cargo test -p dexdec --test reference_queries`
- [x] `cargo build -p dexdec --bin dexdec`
- [ ] Optional: full large multi-DEX corpus smoke (requires local APK corpus; not required for CI)

No CI configuration is changed.


Made with [Cursor](https://cursor.com)