### PR TITLE
Preserve synchronized continuations and handler boundaries

### DIFF
--- a/dexdec/src/analysis/value_recovery/predicate_regions.rs
+++ b/dexdec/src/analysis/value_recovery/predicate_regions.rs
@@ -47,7 +47,7 @@ impl PredicateRegionFormation {
     ) -> Result<SemanticNode, ValueRecoveryError> {
         let mut formed = Vec::<SemanticNode>::with_capacity(nodes.len());
         for node in nodes {
-            let merged = match (formed.last_mut(), &node) {
+            let merged = match (formed.last(), &node) {
                 (
                     Some(SemanticNode::If {
                         condition,
@@ -64,18 +64,26 @@ impl PredicateRegionFormation {
                 _ => None,
             };
             if let Some(next) = merged {
-                let previous = std::mem::replace(
-                    match formed.last_mut() {
-                        Some(SemanticNode::If { then_node, .. }) => then_node,
-                        _ => unreachable!("predicate region candidate changed"),
-                    },
-                    Box::new(SemanticNode::Empty),
-                );
-                if let Some(SemanticNode::If { then_node, .. }) = formed.last_mut() {
-                    *then_node = Box::new(SemanticNode::sequence([*previous, next]));
+                let previous = formed
+                    .last()
+                    .cloned()
+                    .expect("predicate region candidate disappeared");
+                let mut candidate = previous.clone();
+                if let SemanticNode::If { then_node, .. } = &mut candidate {
+                    let body = std::mem::replace(then_node, Box::new(SemanticNode::Empty));
+                    *then_node = Box::new(SemanticNode::sequence([*body, next]));
+                } else {
+                    unreachable!("predicate region candidate changed");
                 }
-                self.changed = true;
-                continue;
+                let original = SemanticNode::sequence([previous, node.clone()]);
+                if SemanticCompletion::analyze(&original) == SemanticCompletion::analyze(&candidate)
+                {
+                    *formed
+                        .last_mut()
+                        .expect("predicate region candidate disappeared") = candidate;
+                    self.changed = true;
+                    continue;
+                }
             }
 
             if let SemanticNode::If {
@@ -357,5 +365,58 @@ impl SemanticFolder for PredicateRegionFormation {
             SemanticNode::BasicBlock(block) => Ok(self.form_block(block)),
             node => Ok(node),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{
+        ArgType, InsnNode, InsnType, InstructionId, LiteralArg, RegionId, SemanticExpression,
+        SemanticLeave, SemanticLeaveKind,
+    };
+
+    fn predicate(id: usize) -> SemanticPredicate {
+        let mut instruction = InsnNode::new(InsnType::If, 0);
+        instruction.id = InstructionId::new(id);
+        SemanticPredicate::Test(
+            crate::ir::SemanticOperation::from_instruction(instruction).unwrap(),
+        )
+    }
+
+    fn leave(kind: SemanticLeaveKind) -> SemanticNode {
+        let region = RegionId::new(0);
+        SemanticNode::Leave(SemanticLeave {
+            site: None,
+            condition: None,
+            kind,
+            edge: None,
+            origin: None,
+            source: region,
+            destination: region,
+            target: region,
+            cleanup: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn rejects_equivalent_guard_merge_that_drops_an_abrupt_outcome() {
+        let condition = predicate(1);
+        let mut root = SemanticNode::sequence([
+            SemanticNode::guard(
+                condition.clone(),
+                leave(SemanticLeaveKind::Throw(SemanticExpression::Literal(
+                    LiteralArg::new(0, ArgType::INT),
+                ))),
+            ),
+            SemanticNode::guard(condition, leave(SemanticLeaveKind::Return(None))),
+        ]);
+        let before = SemanticCompletion::analyze(&root);
+
+        let changed = PredicateRegionFormation::apply(&mut root).unwrap();
+
+        assert!(!changed);
+        assert_eq!(SemanticCompletion::analyze(&root), before);
+        assert!(matches!(root, SemanticNode::Sequence(nodes) if nodes.len() == 2));
     }
 }

--- a/dexdec/src/analysis/value_recovery/predicate_regions/distribution.rs
+++ b/dexdec/src/analysis/value_recovery/predicate_regions/distribution.rs
@@ -61,6 +61,19 @@ impl GuardDistribution {
         if new_cost >= old_cost {
             return Ok((original, false));
         }
+        let original_region = SemanticNode::sequence([
+            original.clone(),
+            SemanticNode::If {
+                condition: guard.clone(),
+                then_node: Box::new(tail.clone()),
+                else_node: None,
+            },
+        ]);
+        if SemanticCompletion::analyze(&original_region)
+            != SemanticCompletion::analyze(&injected.node)
+        {
+            return Ok((original, false));
+        }
         Ok((injected.node, true))
     }
 
@@ -421,4 +434,83 @@ enum InjectionTask {
     Visit { node: SemanticNode, path: Bdd },
     Sequence(Vec<SemanticNode>),
     If { condition: SemanticPredicate },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{
+        BlockId, InsnNode, InsnType, InstructionId, RegionId, SemanticBlock, SemanticLeave,
+        SemanticLeaveKind, SemanticOperand, SemanticStatement,
+    };
+
+    fn predicate(id: usize) -> SemanticPredicate {
+        let mut instruction = InsnNode::new(InsnType::If, 0);
+        instruction.id = InstructionId::new(id);
+        SemanticPredicate::Test(SemanticOperation::from_instruction(instruction).unwrap())
+    }
+
+    fn return_node() -> SemanticNode {
+        let region = RegionId::new(0);
+        SemanticNode::Leave(SemanticLeave {
+            site: None,
+            condition: None,
+            kind: SemanticLeaveKind::Return(None),
+            edge: None,
+            origin: None,
+            source: region,
+            destination: region,
+            target: region,
+            cleanup: Vec::new(),
+        })
+    }
+
+    fn no_return_block() -> SemanticNode {
+        let mut instruction = InsnNode::new(InsnType::Invoke, 0);
+        instruction.id = InstructionId::new(3);
+        instruction.payload.no_return = true;
+        SemanticNode::BasicBlock(SemanticBlock {
+            id: BlockId::new(3),
+            statements: vec![SemanticStatement::instruction(instruction).unwrap()],
+        })
+    }
+
+    #[test]
+    fn rejects_distribution_that_changes_structural_completion() {
+        let first = predicate(1);
+        let second = predicate(2);
+        let prefix = SemanticNode::guard(
+            first.clone().negate(),
+            SemanticNode::guard(second.clone(), return_node()),
+        );
+        let guard = SemanticPredicate::Or(vec![first, second.negate()]);
+        let tail = no_return_block();
+
+        let domain = PredicateDomain::collect(&prefix, &guard).unwrap();
+        let guard_domain = domain.compile(&guard).unwrap();
+        let injected = PathInjector::new(&domain, guard_domain, &tail)
+            .inject(prefix.clone())
+            .unwrap();
+        let original_region = SemanticNode::sequence([
+            prefix.clone(),
+            SemanticNode::guard(guard.clone(), tail.clone()),
+        ]);
+
+        assert!(SemanticCompletion::analyze(&original_region).can_complete_normally());
+        assert!(!SemanticCompletion::analyze(&injected.node).can_complete_normally());
+        assert!(
+            GuardDistribution::node_cost(&injected.node) < {
+                GuardDistribution::node_cost(&prefix)
+                    + GuardDistribution::predicate_cost(&guard)
+                    + GuardDistribution::node_cost(&tail)
+                    + 1
+            }
+        );
+
+        let (result, changed) =
+            GuardDistribution::apply(prefix, &SemanticOperand::new(guard), &tail).unwrap();
+
+        assert!(!changed);
+        assert!(SemanticCompletion::analyze(&result).can_complete_normally());
+    }
 }

--- a/dexdec/src/decoder/method_decoder.rs
+++ b/dexdec/src/decoder/method_decoder.rs
@@ -1079,10 +1079,9 @@ impl<'a> MethodDecoder<'a> {
             regs
         };
 
-        // filled-new-array returns the result in move-result, so no dest here
-        // We create a placeholder destination that will be filled by move-result
-        let dest = RegisterArg::new(0, ArgType::unknown_object());
-        Some(InsnNode::filled_new_array(dest, type_idx, args))
+        // The array is only assigned a register when a following move-result-object
+        // consumes it. BindResults attaches that destination later.
+        Some(InsnNode::filled_new_array(type_idx, args))
     }
 }
 
@@ -1386,5 +1385,31 @@ mod tests {
         assert_eq!(result.insns.len(), 2);
         assert!(matches!(result.insns[0].insn_type, InsnType::Const));
         assert!(matches!(result.insns[1].insn_type, InsnType::Return));
+    }
+
+    #[test]
+    fn unconsumed_filled_new_array_has_no_placeholder_result() {
+        let code = MethodCode {
+            registers_size: 2,
+            ins_size: 0,
+            outs_size: 0,
+            insns: vec![
+                0x1024, // filled-new-array {v1}, type@0
+                0x0000, 0x0001, 0x1012, // const/4 v0, 1
+                0x000e, // return-void
+            ],
+            tries: vec![],
+            debug_info: None,
+        };
+
+        let result = MethodDecoder::from_code(&code).decode();
+
+        assert_eq!(result.insns.len(), 3);
+        assert_eq!(result.insns[0].insn_type, InsnType::FilledNewArray);
+        assert!(result.insns[0].result.is_none());
+        assert_eq!(
+            result.insns[1].result.as_ref().map(|result| result.reg_num),
+            Some(0)
+        );
     }
 }

--- a/dexdec/src/ir/analysis/effects.rs
+++ b/dexdec/src/ir/analysis/effects.rs
@@ -1,6 +1,8 @@
 //! Source-observable instruction effects shared by dataflow analyses.
 
-use crate::ir::{ArgType, InsnArg, InsnNode, InsnType, MemberReference, MethodReference};
+use crate::ir::{
+    ArgType, InsnArg, InsnNode, InsnType, InvokeType, MemberReference, MethodReference,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThrowEffect {
@@ -243,6 +245,23 @@ impl InstructionEffects {
                 | InsnType::MoveException
                 | InsnType::Phi
         )
+    }
+
+    /// Kotlin emits these no-op calls to delimit inlined `finally` bodies.
+    /// They carry compiler structure but no source-level execution semantics.
+    pub fn is_kotlin_finally_marker(instruction: &InsnNode) -> bool {
+        if instruction.insn_type != InsnType::Invoke
+            || instruction.payload.invoke_type != Some(InvokeType::Static)
+        {
+            return false;
+        }
+        let Some(MemberReference::Method(method)) = instruction.payload.reference.as_ref() else {
+            return false;
+        };
+        method.owner == ArgType::object("kotlin/jvm/internal/InlineMarker")
+            && matches!(method.name.as_str(), "finallyStart" | "finallyEnd")
+            && method.descriptor.parameters == [ArgType::INT]
+            && method.descriptor.return_type == ArgType::VOID
     }
 
     pub fn can_relocate(self) -> bool {

--- a/dexdec/src/ir/exception.rs
+++ b/dexdec/src/ir/exception.rs
@@ -21,7 +21,7 @@ use super::analysis::{
     SsaVar, SubtypeRelation, ThrowEffect, TypeHierarchy,
 };
 use super::semantic::StatementOrigin;
-use super::{ArgType, BlockId, EdgeKind, InsnArg, InsnType, RegisterArg, CFG};
+use super::{ArgType, BlockId, EdgeKind, InsnArg, InsnType, MemberReference, RegisterArg, CFG};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HandlerKind {
@@ -466,6 +466,12 @@ impl<'a> ExceptionAnalyzer<'a> {
         HandlerDomains::assign(self.cfg, &mut regions);
         ElidedHandlerTails::new(self.cfg, &elided_instructions).trim(&mut regions);
         regions = ElidedExceptionScopes::prune(self.cfg, regions, &elided_instructions);
+        PrecedingHandlerProtectionArtifacts::prune(
+            self.cfg,
+            &mut regions,
+            self.hierarchy,
+            self.values,
+        );
         HandlerProtectedPartition::apply(self.cfg, &mut regions)?;
         HandlerDomains::assign(self.cfg, &mut regions);
         let live_handler_adapters = regions
@@ -758,6 +764,170 @@ impl<'a> ExceptionAnalyzer<'a> {
             }
         }
         reachable
+    }
+}
+
+/// Removes a source-layout artifact created when two lexical try statements
+/// are adjacent but the first statement's handler is emitted inside the
+/// second statement's physical DEX range. The later range has a raw exception
+/// edge from that handler, but the detached handler is not part of the later
+/// source try statement. Pruning requires every terminal path through the
+/// preceding handler to throw a known type that the later handlers cannot
+/// catch; a matching throw proves that the ranges are lexically nested instead.
+struct PrecedingHandlerProtectionArtifacts;
+
+impl PrecedingHandlerProtectionArtifacts {
+    fn prune(
+        cfg: &CFG,
+        regions: &mut [TryRegion],
+        hierarchy: &dyn TypeHierarchy,
+        values: &SsaValueGraph,
+    ) {
+        let snapshots = regions.to_vec();
+        for protected in regions {
+            // A catch-all range commonly protects monitor-exit or resource
+            // cleanup emitted in an earlier handler. That ownership is
+            // intentional even when the ranges happen to be adjacent.
+            if protected
+                .handlers
+                .iter()
+                .any(|handler| handler.catch_type.is_none())
+            {
+                continue;
+            }
+            let own_handlers = protected
+                .handlers
+                .iter()
+                .map(|handler| handler.canonical_entry)
+                .collect::<BTreeSet<_>>();
+            let protected_handlers = ClauseKey(
+                protected
+                    .handlers
+                    .iter()
+                    .map(|handler| (handler.catch_type.clone(), handler.handler_offset))
+                    .collect(),
+            );
+            let protected_blocks = protected.blocks.iter().copied().collect::<BTreeSet<_>>();
+            let artifacts = snapshots
+                .iter()
+                .filter(|owner| owner.id != protected.id)
+                .filter(|owner| owner.end_offset == protected.start_offset)
+                .flat_map(|owner| &owner.handlers)
+                .filter(|handler| !own_handlers.contains(&handler.canonical_entry))
+                .filter(|handler| Self::detached(cfg, handler, &protected_blocks))
+                .filter(|handler| {
+                    Self::terminal_throws_escape(
+                        cfg,
+                        handler,
+                        &protected_handlers,
+                        hierarchy,
+                        values,
+                    )
+                })
+                .flat_map(|handler| {
+                    handler
+                        .blocks
+                        .iter()
+                        .chain(&handler.entry_blocks)
+                        .chain(&handler.adapter_blocks)
+                        .copied()
+                })
+                .collect::<BTreeSet<_>>();
+            protected.blocks.retain(|block| !artifacts.contains(block));
+        }
+    }
+
+    fn detached(cfg: &CFG, handler: &CatchHandler, protected: &BTreeSet<BlockId>) -> bool {
+        let domain = handler
+            .blocks
+            .iter()
+            .chain(&handler.entry_blocks)
+            .chain(&handler.adapter_blocks)
+            .copied()
+            .collect::<BTreeSet<_>>();
+        !domain.is_empty()
+            && domain.iter().all(|block| {
+                cfg.normal_successors(*block)
+                    .all(|target| domain.contains(&target) || !protected.contains(&target))
+            })
+    }
+
+    fn terminal_throws_escape(
+        cfg: &CFG,
+        handler: &CatchHandler,
+        protected_handlers: &ClauseKey,
+        hierarchy: &dyn TypeHierarchy,
+        values: &SsaValueGraph,
+    ) -> bool {
+        let domain = handler
+            .blocks
+            .iter()
+            .chain(&handler.entry_blocks)
+            .chain(&handler.adapter_blocks)
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let mut saw_terminal = false;
+        for block in &domain {
+            if cfg
+                .normal_successors(*block)
+                .any(|target| domain.contains(&target))
+            {
+                continue;
+            }
+            let Some(terminal) = cfg.block(*block).and_then(|block| block.terminator()) else {
+                return false;
+            };
+            if terminal.insn_type != InsnType::Throw {
+                return false;
+            }
+            let Some(thrown) = terminal
+                .args
+                .first()
+                .and_then(|argument| Self::thrown_type(cfg, values, argument))
+            else {
+                return false;
+            };
+            if protected_handlers.catches(thrown, hierarchy) {
+                return false;
+            }
+            saw_terminal = true;
+        }
+        saw_terminal
+    }
+
+    fn thrown_type<'cfg>(
+        cfg: &'cfg CFG,
+        values: &SsaValueGraph,
+        argument: &'cfg InsnArg,
+    ) -> Option<&'cfg str> {
+        if let Some(ty) = argument.declared_type().and_then(ArgType::as_object) {
+            return Some(ty);
+        }
+        let value = argument
+            .as_register()
+            .and_then(SsaVar::from_reg)
+            .and_then(|value| values.value(value))?;
+        let definition = value.definition?;
+        let instruction = cfg
+            .block(definition.block)
+            .and_then(|block| block.insns.get(definition.index))?;
+        instruction
+            .result
+            .as_ref()
+            .and_then(|result| result.ty.as_object())
+            .or_else(|| {
+                instruction
+                    .payload
+                    .class_type
+                    .as_ref()
+                    .and_then(ArgType::as_object)
+            })
+            .or_else(|| match instruction.payload.reference.as_ref() {
+                Some(MemberReference::Method(method)) if method.is_constructor() => {
+                    method.owner.as_object()
+                }
+                _ => None,
+            })
     }
 }
 
@@ -3897,7 +4067,193 @@ impl<'a> FiniteExitAnalysis<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::analysis::ClassHierarchyIndex;
     use crate::ir::{Block, InsnNode};
+
+    fn exception_hierarchy() -> ClassHierarchyIndex {
+        let mut hierarchy = ClassHierarchyIndex::default();
+        hierarchy.add("java/lang/Object", Vec::new());
+        hierarchy.add("java/lang/Throwable", vec!["java/lang/Object".to_string()]);
+        hierarchy.add(
+            "java/lang/Exception",
+            vec!["java/lang/Throwable".to_string()],
+        );
+        hierarchy.add(
+            "java/lang/RuntimeException",
+            vec!["java/lang/Exception".to_string()],
+        );
+        hierarchy.add(
+            "test/AnnotatedException",
+            vec!["java/lang/Exception".to_string()],
+        );
+        hierarchy
+    }
+
+    fn catch_handler(entry: u32, blocks: &[u32]) -> CatchHandler {
+        let blocks = blocks.iter().copied().map(BlockId::new).collect::<Vec<_>>();
+        CatchHandler {
+            id: entry,
+            catch_type: Some(ArgType::object("java/lang/Exception")),
+            handler_offset: entry,
+            entry_blocks: BTreeSet::from([BlockId::new(entry)]),
+            handler_block: BlockId::new(entry),
+            semantic_entry: BlockId::new(entry),
+            canonical_entry: BlockId::new(entry),
+            adapter_blocks: BTreeSet::new(),
+            semantic_blocks: blocks.clone(),
+            lexical_blocks: blocks.clone(),
+            blocks,
+            continuation: None,
+            exception_value: None,
+            canonical_exception_value: None,
+            rethrow_blocks: BTreeSet::new(),
+            kind: HandlerKind::Catch,
+        }
+    }
+
+    fn try_region(
+        id: u32,
+        start: u32,
+        end: u32,
+        blocks: &[u32],
+        handlers: Vec<CatchHandler>,
+    ) -> TryRegion {
+        TryRegion {
+            id,
+            start_offset: start,
+            end_offset: end,
+            blocks: blocks.iter().copied().map(BlockId::new).collect(),
+            handlers,
+            parent: None,
+            children: Vec::new(),
+            normal_exit_blocks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn detached_preceding_handler_is_not_owned_by_adjacent_try() {
+        let mut cfg = CFG::new("adjacent_handler_protection");
+        for block in 0..=4 {
+            cfg.add_block(Block::new(block));
+        }
+        cfg.add_edge(BlockId::new(0), BlockId::new(1), EdgeKind::Exception);
+        cfg.add_edge(BlockId::new(0), BlockId::new(3), EdgeKind::Normal);
+        cfg.add_edge(BlockId::new(3), BlockId::new(4), EdgeKind::Exception);
+        cfg.add_edge(BlockId::new(1), BlockId::new(2), EdgeKind::Normal);
+        let constructed = RegisterArg::new_ssa(0, 0, ArgType::object("java/lang/RuntimeException"));
+        let mut construction = InsnNode::new(InsnType::Constructor, 0);
+        construction.set_result(constructed);
+        cfg.block_mut(BlockId::new(1)).unwrap().push(construction);
+        cfg.block_mut(BlockId::new(2))
+            .unwrap()
+            .push(InsnNode::throw(InsnArg::reg_ssa(
+                0,
+                0,
+                ArgType::unknown_object(),
+            )));
+        let values = SsaValueGraph::build(&cfg).unwrap();
+        let mut outer = catch_handler(4, &[4]);
+        outer.catch_type = Some(ArgType::object("test/AnnotatedException"));
+        let mut regions = vec![
+            try_region(0, 10, 20, &[0], vec![catch_handler(1, &[1, 2])]),
+            try_region(1, 20, 40, &[1, 2, 3], vec![outer]),
+        ];
+
+        PrecedingHandlerProtectionArtifacts::prune(
+            &cfg,
+            &mut regions,
+            &exception_hierarchy(),
+            &values,
+        );
+
+        assert_eq!(regions[1].blocks, vec![BlockId::new(3)]);
+    }
+
+    #[test]
+    fn preceding_handler_flowing_into_adjacent_try_remains_protected() {
+        let mut cfg = CFG::new("connected_adjacent_handler_protection");
+        for block in 0..=4 {
+            cfg.add_block(Block::new(block));
+        }
+        cfg.add_edge(BlockId::new(1), BlockId::new(2), EdgeKind::Normal);
+        cfg.add_edge(BlockId::new(2), BlockId::new(3), EdgeKind::Normal);
+        let mut regions = vec![
+            try_region(0, 10, 20, &[0], vec![catch_handler(1, &[1, 2])]),
+            try_region(1, 20, 40, &[1, 2, 3], vec![catch_handler(4, &[4])]),
+        ];
+
+        PrecedingHandlerProtectionArtifacts::prune(
+            &cfg,
+            &mut regions,
+            &exception_hierarchy(),
+            &SsaValueGraph::default(),
+        );
+
+        assert_eq!(
+            regions[1].blocks,
+            vec![BlockId::new(1), BlockId::new(2), BlockId::new(3)]
+        );
+    }
+
+    #[test]
+    fn catch_all_keeps_preceding_handler_protected_for_cleanup() {
+        let mut cfg = CFG::new("catch_all_cleanup_protection");
+        for block in 0..=4 {
+            cfg.add_block(Block::new(block));
+        }
+        cfg.add_edge(BlockId::new(1), BlockId::new(2), EdgeKind::Normal);
+        let mut cleanup = catch_handler(4, &[4]);
+        cleanup.catch_type = None;
+        let mut regions = vec![
+            try_region(0, 10, 20, &[0], vec![catch_handler(1, &[1, 2])]),
+            try_region(1, 20, 40, &[1, 2, 3], vec![cleanup]),
+        ];
+
+        PrecedingHandlerProtectionArtifacts::prune(
+            &cfg,
+            &mut regions,
+            &exception_hierarchy(),
+            &SsaValueGraph::default(),
+        );
+
+        assert_eq!(
+            regions[1].blocks,
+            vec![BlockId::new(1), BlockId::new(2), BlockId::new(3)]
+        );
+    }
+
+    #[test]
+    fn caught_throw_keeps_preceding_handler_inside_adjacent_try() {
+        let mut cfg = CFG::new("caught_handler_throw");
+        for block in 0..=4 {
+            cfg.add_block(Block::new(block));
+        }
+        cfg.add_edge(BlockId::new(1), BlockId::new(2), EdgeKind::Normal);
+        cfg.block_mut(BlockId::new(2))
+            .unwrap()
+            .push(InsnNode::throw(InsnArg::reg(
+                0,
+                ArgType::object("test/AnnotatedException"),
+            )));
+        let mut outer = catch_handler(4, &[4]);
+        outer.catch_type = Some(ArgType::object("test/AnnotatedException"));
+        let mut regions = vec![
+            try_region(0, 10, 20, &[0], vec![catch_handler(1, &[1, 2])]),
+            try_region(1, 20, 40, &[1, 2, 3], vec![outer]),
+        ];
+
+        PrecedingHandlerProtectionArtifacts::prune(
+            &cfg,
+            &mut regions,
+            &exception_hierarchy(),
+            &SsaValueGraph::default(),
+        );
+
+        assert_eq!(
+            regions[1].blocks,
+            vec![BlockId::new(1), BlockId::new(2), BlockId::new(3)]
+        );
+    }
 
     #[test]
     fn handler_adapter_stops_at_exception_state_transfer() {

--- a/dexdec/src/ir/insn.rs
+++ b/dexdec/src/ir/insn.rs
@@ -1034,9 +1034,8 @@ impl InsnNode {
     }
 
     /// Create a FILLED_NEW_ARRAY instruction
-    pub fn filled_new_array(dest: RegisterArg, type_idx: u32, elements: Vec<InsnArg>) -> Self {
+    pub fn filled_new_array(type_idx: u32, elements: Vec<InsnArg>) -> Self {
         let mut insn = Self::new(InsnType::FilledNewArray, elements.len());
-        insn.set_result(dest);
         for elem in elements {
             insn.add_arg(elem);
         }

--- a/dexdec/src/ir/passes/split_monitor_entries.rs
+++ b/dexdec/src/ir/passes/split_monitor_entries.rs
@@ -1,6 +1,6 @@
-//! Isolate every `monitor-enter` at a CFG boundary.
+//! Isolate monitor bodies and post-release continuations at CFG boundaries.
 
-use crate::ir::{Block, BlockId, EdgeKind, InsnType, CFG};
+use crate::ir::{analysis::InstructionEffects, Block, BlockId, EdgeKind, InsnNode, InsnType, CFG};
 
 use super::{Pass, PassResult};
 
@@ -32,7 +32,7 @@ impl Pass for SplitMonitorEntries {
     type Error = MonitorSplitError;
 
     fn name(&self) -> &'static str {
-        "split_monitor_entries"
+        "split_monitor_boundaries"
     }
 
     fn run(&mut self, cfg: &mut CFG) -> Result<PassResult, Self::Error> {
@@ -41,12 +41,8 @@ impl Pass for SplitMonitorEntries {
             .block_ids()
             .into_iter()
             .filter(|block| {
-                cfg.block(*block).is_some_and(|block| {
-                    block.insns.iter().enumerate().any(|(index, instruction)| {
-                        instruction.insn_type == InsnType::MonitorEnter
-                            && index + 1 < block.insns.len()
-                    })
-                })
+                cfg.block(*block)
+                    .is_some_and(|block| !Self::partition_boundaries(&block.insns).is_empty())
             })
             .collect::<Vec<_>>();
         if candidates.is_empty() {
@@ -68,15 +64,7 @@ impl Pass for SplitMonitorEntries {
                     .ok_or(MonitorSplitError::MissingBlock(original_id))?
                     .insns,
             );
-            let mut boundaries = instructions
-                .iter()
-                .enumerate()
-                .filter_map(|(index, instruction)| {
-                    (instruction.insn_type == InsnType::MonitorEnter
-                        && index + 1 < instructions.len())
-                    .then_some(index + 1)
-                })
-                .collect::<Vec<_>>();
+            let mut boundaries = Self::partition_boundaries(&instructions);
             boundaries.push(instructions.len());
 
             cfg.remove_all_edges_from(original_id);
@@ -134,5 +122,114 @@ impl Pass for SplitMonitorEntries {
             }
         }
         Ok(PassResult::Changed)
+    }
+}
+
+impl SplitMonitorEntries {
+    fn partition_boundaries(instructions: &[InsnNode]) -> Vec<usize> {
+        let mut boundaries = Vec::new();
+        for (index, instruction) in instructions.iter().enumerate() {
+            let boundary = match instruction.insn_type {
+                InsnType::MonitorEnter => index + 1,
+                InsnType::MonitorExit => {
+                    let mut boundary = index + 1;
+                    while instructions
+                        .get(boundary)
+                        .is_some_and(InstructionEffects::is_kotlin_finally_marker)
+                    {
+                        boundary += 1;
+                    }
+                    boundary
+                }
+                _ => continue,
+            };
+            if boundary < instructions.len() {
+                boundaries.push(boundary);
+            }
+        }
+        boundaries.sort_unstable();
+        boundaries.dedup();
+        boundaries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ArgType, InsnArg, InvokeType, MemberReference, MethodReference, RegisterArg};
+
+    fn finally_marker(name: &str) -> InsnNode {
+        let mut instruction = InsnNode::invoke(InvokeType::Static, 0, Vec::new());
+        instruction.payload.reference = Some(MemberReference::Method(
+            format!("Lkotlin/jvm/internal/InlineMarker;->{name}(I)V")
+                .parse::<MethodReference>()
+                .unwrap(),
+        ));
+        instruction
+    }
+
+    #[test]
+    fn splits_after_monitor_release_epilogue() {
+        let lock = InsnArg::Reg(RegisterArg::new(0, ArgType::object("java/lang/Object")));
+        let mut block = Block::new(0);
+        block.insns = vec![
+            InsnNode::monitor_enter(lock.clone()),
+            InsnNode::nop(),
+            finally_marker("finallyStart"),
+            InsnNode::monitor_exit(lock),
+            finally_marker("finallyEnd"),
+            InsnNode::nop(),
+        ];
+        let mut cfg = CFG::new("monitor_release_boundary");
+        cfg.add_block(block);
+
+        assert_eq!(
+            SplitMonitorEntries.run(&mut cfg).unwrap(),
+            PassResult::Changed
+        );
+        assert_eq!(
+            cfg.block_ids(),
+            vec![BlockId::new(0), BlockId::new(1), BlockId::new(2)]
+        );
+        assert_eq!(
+            cfg.block(0)
+                .unwrap()
+                .insns
+                .iter()
+                .map(|i| i.insn_type)
+                .collect::<Vec<_>>(),
+            vec![InsnType::MonitorEnter]
+        );
+        assert_eq!(
+            cfg.block(1)
+                .unwrap()
+                .insns
+                .iter()
+                .map(|i| i.insn_type)
+                .collect::<Vec<_>>(),
+            vec![
+                InsnType::Nop,
+                InsnType::Invoke,
+                InsnType::MonitorExit,
+                InsnType::Invoke
+            ]
+        );
+        assert_eq!(
+            cfg.block(2)
+                .unwrap()
+                .insns
+                .iter()
+                .map(|i| i.insn_type)
+                .collect::<Vec<_>>(),
+            vec![InsnType::Nop]
+        );
+        assert_eq!(
+            cfg.normal_successors(0).collect::<Vec<_>>(),
+            vec![BlockId::new(1)]
+        );
+        assert_eq!(
+            cfg.normal_successors(1).collect::<Vec<_>>(),
+            vec![BlockId::new(2)]
+        );
     }
 }

--- a/dexdec/src/ir/region/synchronization.rs
+++ b/dexdec/src/ir/region/synchronization.rs
@@ -6,8 +6,14 @@ use crate::ir::analysis::{
     DominatorTree, InstructionEffects, SsaOrigins, SsaValueGraph, SsaVar, StrongComponents,
 };
 use crate::ir::{
-    BlockId, CatchHandler, InsnArg, InsnNode, InsnType, StatementOrigin, TryRegion, CFG,
+    ArgType, BlockId, CatchHandler, InsnArg, InsnNode, InsnType, StatementOrigin, TryRegion, CFG,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum MonitorIdentity {
+    Ssa(SsaVar),
+    Class(ArgType),
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct SynchronizationFact {
@@ -23,10 +29,12 @@ pub(super) struct SynchronizationAnalysis<'a> {
     cfg: &'a CFG,
     dominators: &'a DominatorTree,
     identities: BTreeMap<SsaVar, SsaVar>,
+    constant_classes: BTreeMap<SsaVar, (ArgType, StatementOrigin)>,
     origins: SsaOrigins,
     ordinary: BTreeSet<BlockId>,
     handler_entries: BTreeSet<BlockId>,
-    proven_release_handlers: BTreeMap<SsaVar, BTreeMap<BlockId, BTreeSet<StatementOrigin>>>,
+    proven_release_handlers:
+        BTreeMap<MonitorIdentity, BTreeMap<BlockId, BTreeSet<StatementOrigin>>>,
 }
 
 impl<'a> SynchronizationAnalysis<'a> {
@@ -44,10 +52,35 @@ impl<'a> SynchronizationAnalysis<'a> {
                 members.into_iter().map(move |member| (member, identity))
             })
             .collect();
+        let constant_classes = values
+            .values()
+            .filter_map(|value| {
+                let position = value.definition?;
+                let instruction = cfg
+                    .block(position.block)
+                    .and_then(|block| block.insns.get(position.index))?;
+                (instruction.insn_type == InsnType::ConstClass)
+                    .then(|| instruction.payload.class_type.clone())
+                    .flatten()
+                    .map(|class| {
+                        (
+                            value.variable,
+                            (
+                                class,
+                                StatementOrigin {
+                                    block: position.block,
+                                    instruction: instruction.id,
+                                },
+                            ),
+                        )
+                    })
+            })
+            .collect();
         let mut analysis = Self {
             cfg,
             dominators,
             identities,
+            constant_classes,
             origins: SsaOrigins::analyze(values),
             ordinary: Self::reachable(cfg, cfg.entry),
             handler_entries: regions
@@ -87,7 +120,7 @@ impl<'a> SynchronizationAnalysis<'a> {
             .cfg
             .block_ids()
             .into_iter()
-            .filter_map(|block| self.monitor_entry(block, release.lock))
+            .filter_map(|block| self.monitor_entry(block, &release.lock))
             .filter_map(|candidate| candidate.prove_scope(self, &release))
             .filter(|candidate| candidate.is_protected_by(self.cfg, region))
             .collect::<Vec<_>>();
@@ -117,7 +150,7 @@ impl<'a> SynchronizationAnalysis<'a> {
         if facts.iter().any(|fact| {
             fact.enter_origin != first.enter_origin
                 || fact.body_entry != first.body_entry
-                || self.identity(&fact.lock) != Some(identity)
+                || self.identity(&fact.lock) != Some(identity.clone())
         }) {
             return None;
         }
@@ -129,6 +162,7 @@ impl<'a> SynchronizationAnalysis<'a> {
             self.cfg,
             &self.identities,
             &self.origins,
+            &self.constant_classes,
             identity,
             &candidate_entries,
         )
@@ -192,6 +226,7 @@ impl<'a> SynchronizationAnalysis<'a> {
                     self.cfg,
                     &self.identities,
                     &self.origins,
+                    &self.constant_classes,
                     identity,
                     &candidate_entries,
                 )
@@ -250,7 +285,7 @@ impl<'a> SynchronizationAnalysis<'a> {
             .collect::<Option<Vec<_>>>()?;
         let locks = handlers
             .iter()
-            .map(|(proof, _)| proof.lock)
+            .map(|(proof, _)| proof.lock.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
@@ -265,7 +300,7 @@ impl<'a> SynchronizationAnalysis<'a> {
                 .extend(proof.releases);
         }
         Some(MonitorReleaseProof {
-            lock: *lock,
+            lock: lock.clone(),
             handler_releases,
         })
     }
@@ -318,12 +353,19 @@ impl<'a> SynchronizationAnalysis<'a> {
                             .first()
                             .and_then(InsnArg::as_register)
                             .and_then(SsaVar::from_reg)
-                            .map(|value| self.canonical(origins.resolve(value)))
+                            .map(|value| self.lock_identity(origins.resolve(value)))
                             .ok_or(ReleaseProofError::MissingLock(block))?;
-                        if lock.is_some_and(|lock| lock != value) {
+                        if lock.as_ref().is_some_and(|lock| lock != &value) {
                             return Err(ReleaseProofError::ConflictingLocks(block));
                         }
                         lock = Some(value);
+                        if let Some(origin) = instruction
+                            .args
+                            .first()
+                            .and_then(|argument| self.release_materialization(block, argument))
+                        {
+                            releases.insert(origin);
+                        }
                         releases.insert(StatementOrigin {
                             block,
                             instruction: instruction.id,
@@ -338,14 +380,20 @@ impl<'a> SynchronizationAnalysis<'a> {
                             .and_then(SsaVar::from_reg);
                         if !released
                             || !thrown.is_some_and(|value| {
-                                self.canonical(origins.resolve(value))
-                                    == self.canonical(origins.resolve(exception))
+                                self.canonical_var(origins.resolve(value))
+                                    == self.canonical_var(origins.resolve(exception))
                             })
                         {
                             return Err(ReleaseProofError::InvalidRethrow(block));
                         }
                         terminal = true;
                         reached_throw = true;
+                    }
+                    _ if InstructionEffects::is_kotlin_finally_marker(instruction) => {
+                        releases.insert(StatementOrigin {
+                            block,
+                            instruction: instruction.id,
+                        });
                     }
                     _ if InstructionEffects::is_ssa_bookkeeping(instruction) => {}
                     _ => {
@@ -382,9 +430,34 @@ impl<'a> SynchronizationAnalysis<'a> {
         Ok(HandlerReleaseProof { lock, releases })
     }
 
-    fn canonical(&self, value: SsaVar) -> SsaVar {
+    fn canonical_var(&self, value: SsaVar) -> SsaVar {
         let value = self.origins.unique(value).unwrap_or(value);
         self.identities.get(&value).copied().unwrap_or(value)
+    }
+
+    fn lock_identity(&self, value: SsaVar) -> MonitorIdentity {
+        let origin = self.origins.unique(value).unwrap_or(value);
+        self.constant_classes
+            .get(&origin)
+            .map(|(class, _)| class.clone())
+            .map(MonitorIdentity::Class)
+            .unwrap_or_else(|| {
+                MonitorIdentity::Ssa(self.identities.get(&origin).copied().unwrap_or(origin))
+            })
+    }
+
+    fn release_materialization(
+        &self,
+        block: BlockId,
+        argument: &InsnArg,
+    ) -> Option<StatementOrigin> {
+        let value = argument.as_register().and_then(SsaVar::from_reg)?;
+        let origin = self.origins.unique(value).unwrap_or(value);
+        self.constant_classes
+            .get(&origin)
+            .map(|(_, origin)| origin)
+            .filter(|origin| origin.block == block)
+            .cloned()
     }
 
     fn cleanup_domain(&self, entry: BlockId) -> BTreeSet<BlockId> {
@@ -422,7 +495,11 @@ impl<'a> SynchronizationAnalysis<'a> {
         reachable
     }
 
-    fn monitor_entry(&self, block: BlockId, cleanup_lock: SsaVar) -> Option<MonitorCandidate> {
+    fn monitor_entry(
+        &self,
+        block: BlockId,
+        cleanup_lock: &MonitorIdentity,
+    ) -> Option<MonitorCandidate> {
         let node = self.cfg.block(block)?;
         let enters = node
             .insns
@@ -434,7 +511,7 @@ impl<'a> SynchronizationAnalysis<'a> {
             return None;
         };
         let lock = enter.args.first()?.clone();
-        (self.identity(&lock)? == cleanup_lock).then_some(())?;
+        (self.identity(&lock)?.eq(cleanup_lock)).then_some(())?;
         let successors = self.cfg.normal_successors(block).collect::<Vec<_>>();
         let [body_entry] = successors.as_slice() else {
             return None;
@@ -455,9 +532,9 @@ impl<'a> SynchronizationAnalysis<'a> {
         })
     }
 
-    fn identity(&self, argument: &InsnArg) -> Option<SsaVar> {
+    fn identity(&self, argument: &InsnArg) -> Option<MonitorIdentity> {
         let value = argument.as_register().and_then(SsaVar::from_reg)?;
-        self.identities.get(&value).copied()
+        Some(self.lock_identity(value))
     }
 }
 
@@ -476,7 +553,8 @@ impl MonitorCandidate {
             analysis.cfg,
             &analysis.identities,
             &analysis.origins,
-            release.lock,
+            &analysis.constant_classes,
+            release.lock.clone(),
             &release.entries(),
         )
         .analyze(self.fact.body_entry)
@@ -518,7 +596,7 @@ impl MonitorCandidate {
 }
 
 struct MonitorReleaseProof {
-    lock: SsaVar,
+    lock: MonitorIdentity,
     handler_releases: BTreeMap<BlockId, BTreeSet<StatementOrigin>>,
 }
 
@@ -543,7 +621,7 @@ impl MonitorReleaseProof {
 
 #[derive(Debug)]
 struct HandlerReleaseProof {
-    lock: SsaVar,
+    lock: MonitorIdentity,
     releases: BTreeSet<StatementOrigin>,
 }
 
@@ -625,7 +703,8 @@ struct MonitorScopeFlow<'a> {
     cfg: &'a CFG,
     identities: &'a BTreeMap<SsaVar, SsaVar>,
     origins: &'a SsaOrigins,
-    lock: SsaVar,
+    constant_classes: &'a BTreeMap<SsaVar, (ArgType, StatementOrigin)>,
+    lock: MonitorIdentity,
     release_entries: &'a BTreeSet<BlockId>,
 }
 
@@ -634,13 +713,15 @@ impl<'a> MonitorScopeFlow<'a> {
         cfg: &'a CFG,
         identities: &'a BTreeMap<SsaVar, SsaVar>,
         origins: &'a SsaOrigins,
-        lock: SsaVar,
+        constant_classes: &'a BTreeMap<SsaVar, (ArgType, StatementOrigin)>,
+        lock: MonitorIdentity,
         release_entries: &'a BTreeSet<BlockId>,
     ) -> Self {
         Self {
             cfg,
             identities,
             origins,
+            constant_classes,
             lock,
             release_entries,
         }
@@ -735,10 +816,17 @@ impl<'a> MonitorScopeFlow<'a> {
                         .first()
                         .ok_or(MonitorScopeError::MalformedMonitor(block))?,
                 );
+            let release_marker = InstructionEffects::is_kotlin_finally_marker(instruction);
+            if depth == 0 && !release_marker {
+                break;
+            }
             // Once lock identity and all-path balance are proven, an
             // IllegalMonitorStateException edge from the compiler-generated
             // release is infeasible in source-level synchronized semantics.
-            if instruction.can_throw() && !scope_release {
+            // Kotlin's finally markers are compiler metadata implemented as
+            // no-op calls, so their synthetic exceptional edges do not leave
+            // a source-level monitor scope either.
+            if instruction.can_throw() && !scope_release && !release_marker {
                 let exceptional_depth = depth;
                 match exceptional {
                     Some(existing) if existing != exceptional_depth => {
@@ -766,6 +854,13 @@ impl<'a> MonitorScopeFlow<'a> {
                         .checked_sub(1)
                         .ok_or(MonitorScopeError::DepthUnderflow(block))?;
                     if before == 1 {
+                        if let Some(origin) = instruction
+                            .args
+                            .first()
+                            .and_then(|argument| self.release_materialization(block, argument))
+                        {
+                            releases.insert(origin);
+                        }
                         releases.insert(StatementOrigin {
                             block,
                             instruction: instruction.id,
@@ -774,8 +869,11 @@ impl<'a> MonitorScopeFlow<'a> {
                 }
                 _ => {}
             }
-            if depth == 0 {
-                break;
+            if release_marker {
+                releases.insert(StatementOrigin {
+                    block,
+                    instruction: instruction.id,
+                });
             }
         }
         Ok(MonitorDepthTransfer {
@@ -790,8 +888,32 @@ impl<'a> MonitorScopeFlow<'a> {
             .as_register()
             .and_then(SsaVar::from_reg)
             .map(|value| self.origins.unique(value).unwrap_or(value))
-            .map(|value| self.identities.get(&value).copied().unwrap_or(value))
+            .map(|origin| {
+                self.constant_classes
+                    .get(&origin)
+                    .map(|(class, _)| class.clone())
+                    .map(MonitorIdentity::Class)
+                    .unwrap_or_else(|| {
+                        MonitorIdentity::Ssa(
+                            self.identities.get(&origin).copied().unwrap_or(origin),
+                        )
+                    })
+            })
             .is_some_and(|identity| identity == self.lock)
+    }
+
+    fn release_materialization(
+        &self,
+        block: BlockId,
+        argument: &InsnArg,
+    ) -> Option<StatementOrigin> {
+        let value = argument.as_register().and_then(SsaVar::from_reg)?;
+        let origin = self.origins.unique(value).unwrap_or(value);
+        self.constant_classes
+            .get(&origin)
+            .map(|(_, origin)| origin)
+            .filter(|origin| origin.block == block)
+            .cloned()
     }
 }
 
@@ -815,4 +937,72 @@ struct MonitorDepthTransfer {
     normal: Option<u32>,
     exceptional: Option<u32>,
     releases: BTreeSet<StatementOrigin>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::analysis::{DominatorTree, SsaValueGraph};
+    use crate::ir::{Block, InvokeType, MemberReference, MethodReference, RegisterArg};
+
+    fn invocation(reference: &str) -> InsnNode {
+        let mut instruction = InsnNode::invoke(InvokeType::Static, 0, Vec::new());
+        instruction.payload.reference = Some(MemberReference::Method(
+            reference.parse::<MethodReference>().unwrap(),
+        ));
+        instruction
+    }
+
+    #[test]
+    fn recognizes_only_kotlin_finally_markers() {
+        assert!(InstructionEffects::is_kotlin_finally_marker(&invocation(
+            "Lkotlin/jvm/internal/InlineMarker;->finallyStart(I)V"
+        )));
+        assert!(InstructionEffects::is_kotlin_finally_marker(&invocation(
+            "Lkotlin/jvm/internal/InlineMarker;->finallyEnd(I)V"
+        )));
+        assert!(!InstructionEffects::is_kotlin_finally_marker(&invocation(
+            "Lkotlin/jvm/internal/Intrinsics;->reifiedOperationMarker(ILjava/lang/String;)V"
+        )));
+        assert!(!InstructionEffects::is_kotlin_finally_marker(&invocation(
+            "Lkotlin/jvm/internal/InlineMarker;->finallyStart(J)V"
+        )));
+    }
+
+    fn constant_class(
+        register: u32,
+        version: u32,
+        type_index: u32,
+        class: &str,
+    ) -> (InsnNode, InsnArg) {
+        let result = RegisterArg::with_ssa(register, ArgType::class(), version);
+        let argument = InsnArg::Reg(result.clone());
+        let mut instruction = InsnNode::const_class(result, type_index);
+        instruction.payload.class_type = Some(ArgType::object(class));
+        (instruction, argument)
+    }
+
+    #[test]
+    fn repeated_const_class_values_have_the_same_monitor_identity() {
+        let (first, first_value) = constant_class(0, 0, 1, "example/Owner");
+        let (second, second_value) = constant_class(1, 0, 1, "example/Owner");
+        let (other, other_value) = constant_class(2, 0, 2, "example/Other");
+        let mut block = Block::new(0);
+        block.insns = vec![first, second, other];
+        let mut cfg = CFG::new("constant_class_monitor_identity");
+        cfg.add_block(block);
+        cfg.identify_instructions();
+        let values = SsaValueGraph::build(&cfg).unwrap();
+        let dominators = DominatorTree::compute(&cfg).unwrap();
+        let analysis = SynchronizationAnalysis::new(&cfg, &values, &dominators, &[]);
+
+        assert_eq!(
+            analysis.identity(&first_value),
+            analysis.identity(&second_value)
+        );
+        assert_ne!(
+            analysis.identity(&first_value),
+            analysis.identity(&other_value)
+        );
+    }
 }

--- a/dexdec/src/language/java/dex.rs
+++ b/dexdec/src/language/java/dex.rs
@@ -3905,14 +3905,17 @@ impl DexJavaDialect {
         &'a self,
         insn: &'a SemanticOperation,
     ) -> Result<&'a ArgType, JavaLoweringError> {
-        let result = insn
-            .result
-            .as_ref()
-            .ok_or(JavaLoweringError::MissingPayload {
-                instruction: insn.insn_type,
-                field: "result",
-            })?;
-        let array_type = self.types.ssa_type(result)?;
+        let array_type = match &insn.result {
+            Some(result) => self.types.ssa_type(result)?,
+            None => insn
+                .payload
+                .class_type
+                .as_ref()
+                .ok_or(JavaLoweringError::MissingPayload {
+                    instruction: insn.insn_type,
+                    field: "result or class_type",
+                })?,
+        };
         array_type
             .as_array_element()
             .ok_or_else(|| JavaLoweringError::InvalidArrayType {
@@ -4631,6 +4634,19 @@ impl JavaDialect for DexJavaDialect {
                     JavaStmt::Expression(
                         self.insn_expr(insn, None, None)?,
                     )
+                }
+            }
+            InsnType::FilledNewArray => {
+                let ty = self.source_type(insn.payload.class_type.as_ref().ok_or(
+                    JavaLoweringError::MissingPayload {
+                        instruction: insn.insn_type,
+                        field: "class_type",
+                    },
+                )?)?;
+                JavaStmt::Variable {
+                    ty,
+                    name: self.synthetic_variable("unusedArray"),
+                    value: Some(self.insn_expr(insn, None, None)?),
                 }
             }
             InsnType::Iput => {

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -253,6 +253,14 @@ impl JavaAstNormalizer {
         catches: Vec<JavaCatch>,
         finally: Option<Box<JavaStmt>>,
     ) -> (JavaStmt, bool) {
+        let empty_finally = finally.as_deref().is_some_and(|finally| match finally {
+            JavaStmt::Empty => true,
+            JavaStmt::Block(statements) => statements.is_empty(),
+            _ => false,
+        });
+        if catches.is_empty() && empty_finally {
+            return (body, true);
+        }
         let empty_body = match &body {
             JavaStmt::Empty => true,
             JavaStmt::Block(statements) => statements.is_empty(),
@@ -1185,6 +1193,21 @@ impl JavaAstRewriter for NameUseCounter<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn removes_try_with_only_an_empty_finally() {
+        let statement = JavaStmt::Expression(JavaExpr::Name(JavaIdentifier::from_dex("work")));
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Try {
+                body: Box::new(statement.clone()),
+                catches: Vec::new(),
+                finally: Some(Box::new(JavaStmt::Block(Vec::new()))),
+            },
+        };
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, statement);
+    }
 
     #[test]
     fn source_completion_appends_default_return_after_semantic_no_return_call() {

--- a/dexdec/src/language/kotlin/dex.rs
+++ b/dexdec/src/language/kotlin/dex.rs
@@ -4793,14 +4793,18 @@ impl DexKotlinDialect {
         &'a self,
         insn: &'a SemanticOperation,
     ) -> Result<&'a ArgType, KotlinLoweringError> {
-        let result = insn
-            .result
-            .as_ref()
-            .ok_or(KotlinLoweringError::MissingPayload {
-                instruction: insn.insn_type,
-                field: "result",
-            })?;
-        let array_type = self.types.ssa_type(result)?;
+        let array_type = match &insn.result {
+            Some(result) => self.types.ssa_type(result)?,
+            None => {
+                insn.payload
+                    .class_type
+                    .as_ref()
+                    .ok_or(KotlinLoweringError::MissingPayload {
+                        instruction: insn.insn_type,
+                        field: "result or class_type",
+                    })?
+            }
+        };
         array_type
             .as_array_element()
             .ok_or_else(|| KotlinLoweringError::InvalidArrayType {
@@ -5541,6 +5545,9 @@ impl KotlinDialect for DexKotlinDialect {
                         self.insn_expr(insn, None, None)?,
                     )
                 }
+            }
+            InsnType::FilledNewArray => {
+                KotlinStmt::Expression(self.insn_expr(insn, None, None)?)
             }
             InsnType::Iput => {
                 let field = Self::field(insn.payload.reference.as_ref())?;

--- a/dexdec/src/language/kotlin/normalize.rs
+++ b/dexdec/src/language/kotlin/normalize.rs
@@ -1661,6 +1661,14 @@ impl KotlinAstNormalizer {
         catches: Vec<KotlinCatch>,
         finally: Option<Box<KotlinStmt>>,
     ) -> (KotlinStmt, bool) {
+        let empty_finally = finally.as_deref().is_some_and(|finally| match finally {
+            KotlinStmt::Empty => true,
+            KotlinStmt::Block(statements) => statements.is_empty(),
+            _ => false,
+        });
+        if catches.is_empty() && empty_finally {
+            return (body, true);
+        }
         let empty_body = match &body {
             KotlinStmt::Empty => true,
             KotlinStmt::Block(statements) => statements.is_empty(),
@@ -2856,6 +2864,21 @@ mod tests {
 
     fn name(value: &str) -> KotlinExpr {
         KotlinExpr::Name(KotlinIdentifier::from_dex(value))
+    }
+
+    #[test]
+    fn removes_try_with_only_an_empty_finally() {
+        let statement = KotlinStmt::Expression(name("work"));
+        let mut body = KotlinMethodBody {
+            root: KotlinStmt::Try {
+                body: Box::new(statement.clone()),
+                catches: Vec::new(),
+                finally: Some(Box::new(KotlinStmt::Block(Vec::new()))),
+            },
+        };
+
+        assert!(KotlinAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, statement);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep adjacent exception handlers attached to the correct protected ranges
- reject predicate rewrites that change abrupt completion and avoid phantom results for unconsumed filled arrays
- recover repeated class monitor identities and preserve code that executes after monitor release

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dexdec --lib` — 439 passed
- 8 dexdec integration targets — 49 passed
- `cargo test -p rusty-dex --lib` — 33 passed
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- version policy tests and TypeScript/Vite production build
- Doubao 13.9 APK: 25/25 affected classes decompiled successfully
- Doubao `classes31.dex`: 5,067/5,067 classes decompiled; fallback stubs stayed 2 -> 2 and unsupported outputs stayed 42 -> 42

The external AOSP corpus retains the same known `aosp_art_050_sync` fixture mismatch as `main`; the failure payload is identical and is not introduced by this change.

## Branch state

Rebased onto merged PR #6 (`9c4b576`): one commit ahead and zero commits behind `main`.