### PR TITLE
Preserve reference producer types across consumers

### DIFF
--- a/dexdec/src/ir/analysis/types/lattice.rs
+++ b/dexdec/src/ir/analysis/types/lattice.rs
@@ -232,14 +232,24 @@ impl TypeLattice {
             let exact_satisfies = state
                 .exact
                 .iter()
-                .all(|bound| Self::is_assignable(bound, candidate, hierarchy));
+                .all(|bound| Self::producer_bound_compatible(bound, candidate, hierarchy));
             let lower_satisfies = state
                 .lower
                 .iter()
-                .all(|bound| Self::lower_bound_compatible(bound, candidate, hierarchy));
+                .all(|bound| Self::producer_bound_compatible(bound, candidate, hierarchy));
             if exact_satisfies && lower_satisfies && Self::domain_accepts(&state.domain, candidate)
             {
                 return Some(candidate.clone());
+            }
+        }
+        if let Some(ty) = strong.as_ref().filter(|ty| Self::is_concrete(ty)) {
+            if state
+                .upper
+                .iter()
+                .all(|upper| Self::producer_bound_compatible(ty, upper, hierarchy))
+                && Self::domain_accepts(&state.domain, ty)
+            {
+                return Some(ty.clone());
             }
         }
         if let Some(candidate) = Self::join_all(state.fallback.iter().cloned(), hierarchy) {
@@ -341,7 +351,12 @@ impl TypeLattice {
         }
     }
 
-    fn lower_bound_compatible(
+    /// Reference producers can be broader than a consumer's required type:
+    /// Java lowering preserves that physical type and inserts a cast or uses a
+    /// generic source projection when the emitted expression is not directly
+    /// assignable. Primitive values cannot use that recovery and must remain
+    /// directly assignable.
+    fn producer_bound_compatible(
         produced: &ArgType,
         expected: &ArgType,
         hierarchy: &dyn TypeHierarchy,
@@ -560,5 +575,117 @@ mod tests {
         let resolved = TypeLattice::solve(&constraints, &ClassHierarchyIndex::default());
 
         assert_eq!(resolved.get(&array), Some(&ArgType::array(value_type)));
+    }
+
+    #[test]
+    fn array_copy_uses_the_narrow_destination_element_type() {
+        let source = SsaVar::new(0, 0);
+        let destination = SsaVar::new(1, 0);
+        let value = SsaVar::new(2, 0);
+        let element = ArgType::object("androidx/compose/ui/node/LayoutNode");
+        let constraints = NormalizedTypeConstraints {
+            members: BTreeMap::from([
+                (source, BTreeSet::from([source])),
+                (destination, BTreeSet::from([destination])),
+                (value, BTreeSet::from([value])),
+            ]),
+            bounds: BTreeMap::from([
+                (
+                    source,
+                    BTreeSet::from([TypeBound::new(
+                        BoundKind::Exact,
+                        ArgType::array(ArgType::object("java/lang/Object")),
+                    )]),
+                ),
+                (
+                    destination,
+                    BTreeSet::from([
+                        TypeBound::new(BoundKind::Lower, ArgType::array(element.clone())),
+                        TypeBound::new(BoundKind::Upper, ArgType::array(element.clone())),
+                    ]),
+                ),
+                (
+                    value,
+                    BTreeSet::from([TypeBound::new(BoundKind::Domain, ArgType::unknown_object())]),
+                ),
+            ]),
+            flows: BTreeSet::new(),
+            upper_flows: BTreeSet::new(),
+            arrays: BTreeSet::from([
+                ArrayConstraint::Read {
+                    array: source,
+                    result: value,
+                },
+                ArrayConstraint::Write {
+                    array: destination,
+                    value,
+                },
+            ]),
+        };
+
+        let mut hierarchy = ClassHierarchyIndex::default();
+        hierarchy.add("java/lang/Object", Vec::new());
+        hierarchy.add(
+            "androidx/compose/ui/node/LayoutNode",
+            vec!["java/lang/Object".to_string()],
+        );
+        let resolved = TypeLattice::solve(&constraints, &hierarchy);
+
+        assert_eq!(resolved.get(&value), Some(&element));
+    }
+
+    #[test]
+    fn incompatible_primitive_producer_does_not_use_the_consumer_type() {
+        let value = SsaVar::new(0, 0);
+        let constraints = NormalizedTypeConstraints {
+            members: BTreeMap::from([(value, BTreeSet::from([value]))]),
+            bounds: BTreeMap::from([(
+                value,
+                BTreeSet::from([
+                    TypeBound::new(BoundKind::Exact, ArgType::BOOLEAN),
+                    TypeBound::new(BoundKind::Upper, ArgType::INT),
+                ]),
+            )]),
+            flows: BTreeSet::new(),
+            upper_flows: BTreeSet::new(),
+            arrays: BTreeSet::new(),
+        };
+
+        let resolved = TypeLattice::solve(&constraints, &ClassHierarchyIndex::default());
+
+        assert_eq!(resolved.get(&value), None);
+    }
+
+    #[test]
+    fn reference_producer_survives_incomparable_consumer_types() {
+        let value = SsaVar::new(4, 11);
+        let view = ArgType::object("android/view/View");
+        let callback = ArgType::object("com/example/SelectionCallback");
+        let constraints = NormalizedTypeConstraints {
+            members: BTreeMap::from([(value, BTreeSet::from([value]))]),
+            bounds: BTreeMap::from([(
+                value,
+                BTreeSet::from([
+                    TypeBound::new(BoundKind::Lower, view.clone()),
+                    TypeBound::new(BoundKind::Upper, view.clone()),
+                    TypeBound::new(BoundKind::Upper, callback),
+                    TypeBound::new(BoundKind::Domain, ArgType::unknown_object()),
+                ]),
+            )]),
+            flows: BTreeSet::new(),
+            upper_flows: BTreeSet::new(),
+            arrays: BTreeSet::new(),
+        };
+
+        let mut hierarchy = ClassHierarchyIndex::default();
+        hierarchy.add("java/lang/Object", Vec::new());
+        hierarchy.add("android/view/View", vec!["java/lang/Object".to_string()]);
+        hierarchy.add(
+            "com/example/SelectionCallback",
+            vec!["java/lang/Object".to_string()],
+        );
+        let resolved = TypeLattice::solve(&constraints, &hierarchy);
+
+        assert_eq!(resolved.get(&value), Some(&view));
     }
 }


### PR DESCRIPTION
## Summary

- Preserve concrete reference producer types when consumers impose different reference bounds, while keeping incompatible primitive bounds strict.
- Recover narrow destination element types across array read/write constraints.
- Add focused lattice tests for array copies, incomparable reference consumers, and primitive conflicts.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dexdec --lib` — 430 passed
- 8 dexdec integration targets — 49 passed
- `cargo test -p rusty-dex --lib` — 33 passed
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- `node --test scripts/version.test.mjs` — 6 passed
- `node scripts/version.mjs check`
- `npm --prefix dexdec-gui ci`
- `npm --prefix dexdec-gui run build`

## Real APK regression

Tested against Doubao 13.9 APK (`SHA-256 5c7363c557374f9d56097dfc733dc7feaedd780f6c931017452a9bd77caa5eba`).

- Full `classes.dex`: main and this branch both decompiled 3,904/3,904 classes with 0 failures.
- Exactly one generated source changed: `androidx.compose.ui.node.OnPositionedDispatcher`.
- `dispatch()` changed from an unresolved-type fallback stub to the complete sort/copy/clear/reverse-dispatch/cache flow.
- Broad output markers improved: `UnsupportedOperationException` 466→465, `unresolved` 1→0, `unsupported` 508→507.
- Direct decompilation from the original APK also succeeded 1/1, and its candidate output matched the extracted-DEX full-run output byte-for-byte.
- The external AOSP differential retained only the existing origin/main baseline mismatch; its failure payload was byte-identical.

## Independence

This branch is based directly on current `main` (`9c4b576`) and does not depend on open PR #7.
