### PR TITLE
Reject colliding qualified names during anonymous lowering

### DIFF
--- a/dexdec/src/analysis/java_backend/anonymous_lowering.rs
+++ b/dexdec/src/analysis/java_backend/anonymous_lowering.rs
@@ -594,9 +594,7 @@ impl AnonymousTypeIdentity {
     fn matches(expected: &JavaType, actual: &JavaType) -> bool {
         match (expected, actual) {
             (JavaType::Class(expected), JavaType::Class(actual)) => {
-                expected.name() == actual.name()
-                    || Self::unqualified_matches(expected, actual)
-                    || Self::unqualified_matches(actual, expected)
+                expected.name() == actual.name() || Self::unqualified_matches(expected, actual)
             }
             _ => expected == actual,
         }
@@ -610,6 +608,27 @@ impl AnonymousTypeIdentity {
             .segments
             .last()
             .is_some_and(|expected| expected.name == actual.name)
+    }
+}
+
+#[cfg(test)]
+mod anonymous_type_identity_tests {
+    use super::*;
+
+    #[test]
+    fn qualified_identity_accepts_its_unqualified_reference() {
+        let identity = JavaType::Class(JavaClassType::from_source("example.Owner.Callback"));
+        let reference = JavaType::Class(JavaClassType::from_source("Callback"));
+
+        assert!(AnonymousTypeIdentity::matches(&identity, &reference));
+    }
+
+    #[test]
+    fn unqualified_identity_rejects_an_external_type_with_the_same_simple_name() {
+        let identity = JavaType::Class(JavaClassType::from_source("b"));
+        let external = JavaType::Class(JavaClassType::from_source("example.external.b"));
+
+        assert!(!AnonymousTypeIdentity::matches(&identity, &external));
     }
 }
 

--- a/dexdec/src/analysis/kotlin_backend/anonymous_lowering.rs
+++ b/dexdec/src/analysis/kotlin_backend/anonymous_lowering.rs
@@ -601,9 +601,7 @@ impl AnonymousTypeIdentity {
     fn matches(expected: &KotlinType, actual: &KotlinType) -> bool {
         match (expected, actual) {
             (KotlinType::Class(expected), KotlinType::Class(actual)) => {
-                expected.name() == actual.name()
-                    || Self::unqualified_matches(expected, actual)
-                    || Self::unqualified_matches(actual, expected)
+                expected.name() == actual.name() || Self::unqualified_matches(expected, actual)
             }
             _ => expected == actual,
         }
@@ -617,6 +615,27 @@ impl AnonymousTypeIdentity {
             .segments
             .last()
             .is_some_and(|expected| expected.name == actual.name)
+    }
+}
+
+#[cfg(test)]
+mod anonymous_type_identity_tests {
+    use super::*;
+
+    #[test]
+    fn qualified_identity_accepts_its_unqualified_reference() {
+        let identity = KotlinType::Class(KotlinClassType::from_source("example.Owner.Callback"));
+        let reference = KotlinType::Class(KotlinClassType::from_source("Callback"));
+
+        assert!(AnonymousTypeIdentity::matches(&identity, &reference));
+    }
+
+    #[test]
+    fn unqualified_identity_rejects_an_external_type_with_the_same_simple_name() {
+        let identity = KotlinType::Class(KotlinClassType::from_source("b"));
+        let external = KotlinType::Class(KotlinClassType::from_source("example.external.b"));
+
+        assert!(!AnonymousTypeIdentity::matches(&identity, &external));
     }
 }
 


### PR DESCRIPTION
## Summary

- Keep anonymous-type matching directional: a qualified identity may match its unqualified source reference, but an unqualified identity must not match an unrelated qualified type with the same simple name.
- Apply the same rule to Java and Kotlin anonymous lowering.
- Add four focused tests covering accepted shorthand references and rejected package collisions.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dexdec --lib` — 431 passed
- 8 dexdec integration targets — 49 passed
- `cargo test -p rusty-dex --lib` — 33 passed
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- `node --test scripts/version.test.mjs` — 6 passed
- `node scripts/version.mjs check`
- `npm --prefix dexdec-gui ci`
- `npm --prefix dexdec-gui run build`

## Real APK regression

Tested against Doubao 13.9 APK (`SHA-256 5c7363c557374f9d56097dfc733dc7feaedd780f6c931017452a9bd77caa5eba`).

- Full Java decompilation of `classes.dex`: main and this branch both completed 3,904/3,904 classes with 0 failures.
- Exactly three generated sources changed; all changes restore owners/types recorded in DEX descriptors rather than unrelated same-name types.
- Examples include `RomUtils$a`, `request.a`, `utils.a`, and the real Compose `Function0` singleton classes; main incorrectly rewrote these to other simple-name collisions.
- Unsupported/unresolved/fallback marker counts did not increase.
- Direct original-APK tests for all three affected classes passed 3/3 on both Java and Kotlin backends for main and this branch.
- The external AOSP differential retained only the existing origin/main `050-sync` snapshot mismatch.

## Independence

This branch is based directly on current `main` (`9c4b576`) and has no file overlap or dependency on open PRs #7 and #8.
