### PR TITLE
Schedule direct field reads in constructor arguments

### DIFF
--- a/dexdec/src/analysis/java_backend/constructor_syntax.rs
+++ b/dexdec/src/analysis/java_backend/constructor_syntax.rs
@@ -3335,7 +3335,20 @@ impl ConstructorBindings {
             let names = ExpressionNames::collect(argument);
             names.iter().any(|name| self.values.contains_key(name))
                 || ReplayableExpression::check(argument)
+                || Self::passive_field_read(argument)
         })
+    }
+
+    /// A direct field read already occupies one constructor argument position.
+    /// It can separate surrounding one-use bindings without changing their
+    /// left-to-right evaluation order, provided evaluating its receiver is
+    /// itself replayable. The read is neither duplicated nor discarded.
+    fn passive_field_read(expression: &JavaExpr) -> bool {
+        match expression {
+            JavaExpr::Field { owner, .. } => ReplayableExpression::check(owner),
+            JavaExpr::Cast { value, .. } => Self::passive_field_read(value),
+            _ => false,
+        }
     }
 
     fn binding_positions(
@@ -8278,6 +8291,47 @@ mod tests {
                     ] if matches!(when_true.as_ref(), JavaExpr::Call { method, .. }
                         if method == &JavaIdentifier::from_dex("currentTimeMillis"))
                 )
+        ));
+    }
+
+    #[test]
+    fn direct_field_argument_preserves_surrounding_binding_order() {
+        let request = JavaIdentifier::from_dex("request");
+        let first = JavaIdentifier::from_dex("first");
+        let last = JavaIdentifier::from_dex("last");
+        let field = |name: &str| JavaExpr::Field {
+            owner: Box::new(JavaExpr::Name(request.clone())),
+            name: JavaIdentifier::from_dex(name),
+        };
+        let mut statements = vec![
+            JavaStmt::Variable {
+                ty: JavaType::boolean(),
+                name: first.clone(),
+                value: Some(field("first")),
+            },
+            JavaStmt::Variable {
+                ty: JavaType::boolean(),
+                name: last.clone(),
+                value: Some(field("last")),
+            },
+            JavaStmt::ConstructorInvocation {
+                target: JavaConstructorTarget::This,
+                args: vec![JavaExpr::Name(first), field("middle"), JavaExpr::Name(last)],
+            },
+        ];
+
+        ConstructorSyntaxRecovery::schedule_arguments(&mut statements);
+
+        assert!(matches!(
+            statements.as_slice(),
+            [JavaStmt::ConstructorInvocation { args, .. }]
+                if matches!(args.as_slice(), [
+                    JavaExpr::Field { name: first, .. },
+                    JavaExpr::Field { name: middle, .. },
+                    JavaExpr::Field { name: last, .. },
+                ] if first.as_str() == "first"
+                    && middle.as_str() == "middle"
+                    && last.as_str() == "last")
         ));
     }
 


### PR DESCRIPTION
## Summary

- Treat direct instance-field reads on replayable receivers as fixed constructor argument positions.
- Allow surrounding one-use bindings to inline into `this(...)`/`super(...)` without moving or duplicating the direct field read.
- Add a focused ordering regression test.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dexdec --lib` — 428 passed
- 8 dexdec integration targets — 49 passed
- `cargo test -p rusty-dex --lib` — 33 passed
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- `node --test scripts/version.test.mjs` — 6 passed
- `node scripts/version.mjs check`
- `npm --prefix dexdec-gui ci`
- `npm --prefix dexdec-gui run build`

## Real APK regression

Tested against Doubao 13.9 APK (`SHA-256 5c7363c557374f9d56097dfc733dc7feaedd780f6c931017452a9bd77caa5eba`).

- Scanned all 50 DEX shards for constructors that read instance fields before delegating to another constructor of the same class.
- Found 72 matching constructor methods across 70 unique classes; main and this branch decompiled all 70/70 successfully.
- Exactly one source changed: `com.bytedance.forest.model.Request` in `classes20.dex`.
- Main emitted 14 local declarations before `this(...)`, which is illegal Java constructor syntax. This branch emits `this(...)` as the first statement with all 40 field arguments in DEX order.
- Direct decompilation from the original APK reproduced the same isolated fix; no other candidate output changed.
- Full `classes.dex` regression remained 3,904/3,904 with 0 failures and byte-identical source output.
- The external AOSP differential retained only the existing origin/main `050-sync` snapshot mismatch.

## Independence

This branch is based directly on current `main` (`9c4b576`) and has no file overlap or dependency on open PRs #7, #8, and #9.
