### PR TITLE
Reuse resolved phi types through move chains

### DIFF
--- a/dexdec/src/ir/analysis/source_variables/phi.rs
+++ b/dexdec/src/ir/analysis/source_variables/phi.rs
@@ -1912,6 +1912,9 @@ impl<'a> PhiTypeResolver<'a> {
     fn physical_type(&self, mut value: SsaVar) -> Option<ArgType> {
         let mut visited = BTreeSet::new();
         while visited.insert(value) {
+            if let Some(ty) = self.resolved.get(&value) {
+                return Some(ty.clone());
+            }
             if let Some(constant) = self.constants.get(&value) {
                 if let Some(ty) = constant.declared_type().filter(|ty| ty.is_known()) {
                     return Some(ty.clone());
@@ -2561,6 +2564,7 @@ impl SemanticVisitor for EvaluationInstructions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::analysis::ClassHierarchyIndex;
     use crate::ir::{
         Block, EdgeKind, InsnNode, InsnType, LiteralArg, RegionEdge, SemanticExpression,
     };
@@ -2569,6 +2573,41 @@ mod tests {
         let mut value = RegisterArg::new_ssa(register, version, ArgType::INT);
         value.code_var = Some(variable);
         value
+    }
+
+    #[test]
+    fn physical_type_reuses_resolved_phi_through_a_move() {
+        let predecessor = BlockId::new(0);
+        let block_id = BlockId::new(1);
+        let phi_input = RegisterArg::new_ssa(7, 0, ArgType::narrow());
+        let phi_value = RegisterArg::new_ssa(7, 10, ArgType::narrow());
+        let moved = RegisterArg::new_ssa(23, 0, ArgType::narrow());
+        let moved_value = SsaVar::from_reg(&moved).expect("moved SSA value");
+        let mut predecessor_block = Block::new(predecessor);
+        predecessor_block.push(InsnNode::const_value(phi_input.clone(), 0));
+        let mut block = Block::new(block_id);
+        block.push(InsnNode::phi(
+            phi_value.clone(),
+            vec![(predecessor.raw(), InsnArg::Reg(phi_input))],
+        ));
+        block.push(InsnNode::move_insn(moved, InsnArg::Reg(phi_value.clone())));
+        let mut cfg = CFG::new("resolved_phi_move");
+        cfg.entry = predecessor;
+        cfg.add_block(predecessor_block);
+        cfg.add_block(block);
+        cfg.add_edge(predecessor, block_id, EdgeKind::Normal);
+        let values = SsaValueGraph::build(&cfg).expect("SSA graph");
+        let types = SsaTypeEnvironment::default();
+        let constants = BTreeMap::new();
+        let hierarchy = ClassHierarchyIndex::default();
+        let resolved = BTreeMap::from([(
+            SsaVar::from_reg(&phi_value).expect("phi SSA value"),
+            ArgType::BOOLEAN,
+        )]);
+        let resolver =
+            PhiTypeResolver::new(&cfg, &values, &types, &constants, &hierarchy, &resolved);
+
+        assert_eq!(resolver.physical_type(moved_value), Some(ArgType::BOOLEAN));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reuse an already resolved phi type while physical type analysis follows a value through move instructions.
- Prevent a narrow moved value from remaining unresolved after its source phi was resolved.
- Add a focused SSA regression test for a boolean phi followed by a move.

## Validation

- cargo fmt --all -- --check
- cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp
- cargo test -p dexdec --lib — 428 passed
- 8 dexdec integration targets — 49 passed
- cargo test -p rusty-dex --lib — 33 passed
- node --test scripts/version.test.mjs — 6 passed
- node scripts/version.mjs check
- npm --prefix dexdec-gui ci
- npm --prefix dexdec-gui run build
- External AOSP differential retains only the existing origin/main aosp_art_050_sync snapshot mismatch

## Real APK regression

Tested against Doubao 13.9 APK, SHA-256 5c7363c557374f9d56097dfc733dc7feaedd780f6c931017452a9bd77caa5eba.

- Full classes44.dex comparison used identical input, SHA-256 4c08ad0e1ca38f546377e4aa96b75cda7908ddb3e43dbb7ae7f19f78139efb97.
- Main and this branch both decompiled 4,982 of 4,982 classes with zero class failures.
- Exactly one source changed: io.reactivex.internal.operators.flowable.FlowablePublish.java.
- Main emitted a failure stub for dispatch because v23_Some(2) had an unresolved type.
- This branch resolves the moved phi as boolean and emits the complete method; the class passes Java syntax parsing apart from expected missing dependency symbols.
- The other 4,981 generated source files are byte-identical; method failure stubs decrease from 2 to 1.
- This PR only removes the phi type allocation failure. Broader structural fidelity of the complex dispatch control flow remains separate follow-up work.

## Independence

This branch is based directly on current main at 9c4b576, is 0 behind and 1 ahead, and has no file overlap with open PRs #7 through #10.