### PR TITLE
Preserve foreach values used after loops

### DIFF
--- a/dexdec/src/language/java/syntax/loops/facts.rs
+++ b/dexdec/src/language/java/syntax/loops/facts.rs
@@ -52,7 +52,10 @@ impl LoopSyntaxFact {
                     || method.ssa_escapes(local, *iterator_value)
                     || variable
                         .code_var
-                        .is_some_and(|source| method.variable_escapes(local, source))
+                        // For-each removes the iterator-advance definition. A phi may use a
+                        // different SSA value coalesced into the same source variable after
+                        // the loop, so compare uses directly instead of definition/use ratios.
+                        .is_some_and(|source| method.use_count(source) != local.use_count(source))
             }
         }
     }
@@ -245,6 +248,77 @@ enum CountedLoopRejection {
     InvalidContinuationUpdates,
     MissingInitSite,
     MissingUpdateSite,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{BlockId, InsnArg, InsnNode, RegisterArg, SemanticBlock, SemanticStatement};
+
+    fn register(reg_num: u32, version: u32, variable: u32) -> RegisterArg {
+        let mut register = RegisterArg::new(reg_num, ArgType::object("java/lang/Object"));
+        register.ssa_version = Some(version);
+        register.code_var = Some(variable);
+        register
+    }
+
+    fn block(id: u32, statements: Vec<SemanticStatement>) -> SemanticNode {
+        SemanticNode::BasicBlock(SemanticBlock {
+            id: BlockId::new(id),
+            statements,
+        })
+    }
+
+    fn move_statement(result: RegisterArg, source: InsnArg) -> SemanticStatement {
+        SemanticStatement::instruction(InsnNode::mov(result, source))
+            .expect("move should produce a semantic statement")
+    }
+
+    #[test]
+    fn foreach_rejects_a_phi_coalesced_advance_used_after_the_loop() {
+        let advance = register(0, 4, 4);
+        let iteration_value = register(1, 2, 8);
+        let phi_value = register(0, 6, 4);
+        let consumer = register(0, 7, 6);
+        let iterator = register(8, 4, 30);
+        let local = block(
+            1,
+            vec![
+                move_statement(
+                    advance.clone(),
+                    InsnArg::lit(0, ArgType::object("java/lang/Object")),
+                ),
+                move_statement(iteration_value, InsnArg::Reg(advance.clone())),
+            ],
+        );
+        let continuation = block(
+            2,
+            vec![
+                move_statement(
+                    phi_value.clone(),
+                    InsnArg::lit(0, ArgType::object("java/lang/Object")),
+                ),
+                move_statement(consumer, InsnArg::Reg(phi_value)),
+            ],
+        );
+        let method = SemanticNode::sequence([local.clone(), continuation]);
+        let method_facts = SemanticExpressionFacts::of_node(&method);
+        let local_facts = SemanticExpressionFacts::of_node(&local);
+        assert!(!method_facts.variable_escapes(&local_facts, 4));
+
+        let fact = LoopSyntaxFact::ForEach {
+            init: SemanticSiteId(1),
+            variable_value: crate::ir::analysis::SsaVar::from_reg(&advance)
+                .expect("advance should have an SSA identity"),
+            iterator_value: crate::ir::analysis::SsaVar::from_reg(&iterator)
+                .expect("iterator should have an SSA identity"),
+            variable: advance,
+            iterable: SemanticExpression::Register(iterator),
+            advance: InstructionId::new(1),
+            advance_is_statement: true,
+        };
+        assert!(fact.escapes(&method_facts, &local_facts));
+    }
 }
 
 struct IteratorLoopProof<'a> {


### PR DESCRIPTION
## Summary

- reject Java enhanced-for recovery when the iteration value's source variable is still used after the loop
- compare source-variable uses directly because enhanced-for lowering removes the iterator-advance definition and can hide an escaping phi-coalesced value from definition/use ratios
- add a focused regression test for an advance value coalesced with a continuation phi value

## Real APK validation

Validated against Doubao 13.9.0 (`SHA-256 5c7363c557374f9d56097dfc733dc7feaedd780f6c931017452a9bd77caa5eba`), `classes44.dex` (`SHA-256 4c08ad0e1ca38f546377e4aa96b75cda7908ddb3e43dbb7ae7f19f78139efb97`).

On current `origin/main`, enhanced-for recovery drops or leaks the iteration value in two methods:

- `UnlimitedCacheStorage.find(Url, Map)` always returns `null`, even after a match
- `HttpCache.a(...)` references the enhanced-for element after its loop

With this change, both methods retain the explicit iterator value: a matching element is returned and the value is reset to `null` only when the search is exhausted without a match.

A full Java decompilation comparison of `classes44.dex` produced 4,982/4,982 classes on both baseline and candidate. Exactly the two expected files changed:

- `io/ktor/client/plugins/cache/HttpCache.java`
- `io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.java`

The changed files have no `javac` syntax diagnostics; unresolved-symbol diagnostics are expected without the APK's Android/Kotlin dependency classpath. The empty-`if` anomaly count falls from 4 files to 3.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p dexdec --lib` (428 passed)
- 8 non-corpus integration targets (49 passed)
- `cargo test` in `rusty-dex` (33 unit, 1 integration, 2 doc tests passed)
- `node --test scripts/version.test.mjs` (6 passed)
- `npm ci && npm run build` in `dexdec-gui`

The external AOSP corpus still has its pre-existing `aosp_art_050_sync` snapshot mismatch (`printStackTrace(System.out)` versus the current no-argument output); this change does not touch that path.
