### PR TITLE
Recover split finally families and synchronized try nesting

### DIFF
--- a/dexdec/src/ir/analysis/control_contractions.rs
+++ b/dexdec/src/ir/analysis/control_contractions.rs
@@ -116,8 +116,8 @@ impl ControlContractions {
     ///
     /// Cleanup contraction can turn a non-critical physical edge into a
     /// critical quotient edge. When the contracted entry has one external
-    /// ingress and immediately continues inside the same component, its tail
-    /// is the edge-specific copy site.
+    /// ingress and every normal branch remains inside the same component, its
+    /// incoming edge is the edge-specific copy site.
     pub fn normal_copy_site(
         &self,
         cfg: &CFG,
@@ -144,7 +144,7 @@ impl ControlContractions {
             return None;
         }
         let entry_targets = cfg.normal_successors(entry).collect::<BTreeSet<_>>();
-        if entry_targets.len() != 1 || !entry_targets.is_subset(&component) {
+        if entry_targets.is_empty() || !entry_targets.is_subset(&component) {
             return None;
         }
         let edge = cfg
@@ -521,7 +521,10 @@ impl ComponentTerminals {
 mod tests {
     use std::collections::BTreeSet;
 
-    use super::{BlockId, ContractionGraph, CyclePolicy};
+    use super::{
+        BlockId, ContractionGraph, CyclePolicy, EdgeKind, NormalCopySite, RegionEdge, CFG,
+    };
+    use crate::ir::Block;
 
     #[test]
     fn contracts_acyclic_chain_to_its_sink() {
@@ -607,5 +610,49 @@ mod tests {
         assert_eq!(contractions.terminal(BlockId(2)), Some(BlockId(2)));
         assert!(!contractions.contracts_to(BlockId(1), BlockId(2)));
         assert!(!contractions.contracts_to(BlockId(2), BlockId(1)));
+    }
+
+    #[test]
+    fn places_copy_on_branching_contracted_entry_edge() {
+        let predecessor = BlockId::new(0);
+        let entry = BlockId::new(1);
+        let left = BlockId::new(2);
+        let right = BlockId::new(3);
+        let successor = BlockId::new(4);
+        let alternative = BlockId::new(5);
+        let outside = BlockId::new(6);
+        let contractions = ContractionGraph::new([
+            (entry, left),
+            (entry, right),
+            (left, successor),
+            (right, successor),
+        ])
+        .solve(CyclePolicy::Canonical);
+        let mut cfg = CFG::new("branching_contracted_entry");
+        for block in 0..=6 {
+            cfg.add_block(Block::new(block));
+        }
+        cfg.add_edge(predecessor, entry, EdgeKind::True);
+        cfg.add_edge(predecessor, alternative, EdgeKind::False);
+        cfg.add_edge(entry, left, EdgeKind::True);
+        cfg.add_edge(entry, right, EdgeKind::False);
+        cfg.add_edge(left, successor, EdgeKind::Normal);
+        cfg.add_edge(right, successor, EdgeKind::Normal);
+
+        assert_eq!(
+            contractions.normal_copy_site(&cfg, predecessor, entry, successor),
+            Some(NormalCopySite::Edge(RegionEdge {
+                source: predecessor,
+                target: entry,
+                kind: EdgeKind::True,
+            }))
+        );
+
+        cfg.add_edge(entry, outside, EdgeKind::SwitchDefault);
+        assert_eq!(
+            contractions.normal_copy_site(&cfg, predecessor, entry, successor),
+            None,
+            "a branch leaving the contracted component must reject edge placement"
+        );
     }
 }

--- a/dexdec/src/ir/analysis/control_contractions.rs
+++ b/dexdec/src/ir/analysis/control_contractions.rs
@@ -23,6 +23,13 @@ pub struct ControlContractions {
 }
 
 impl ControlContractions {
+    #[cfg(test)]
+    pub(crate) fn identity() -> Self {
+        Self {
+            domains: Vec::new(),
+        }
+    }
+
     pub fn from_regions(regions: &RegionGraph) -> Self {
         ContractionGraph::new(Self::region_relations(regions)).solve(CyclePolicy::Canonical)
     }

--- a/dexdec/src/ir/analysis/register_liveness.rs
+++ b/dexdec/src/ir/analysis/register_liveness.rs
@@ -13,11 +13,26 @@ pub struct RegisterLiveness {
 impl RegisterLiveness {
     pub fn analyze(cfg: &CFG) -> Self {
         let mut definitions = BTreeMap::new();
+        let mut definitions_before_exception = BTreeMap::new();
         let mut upward_uses = BTreeMap::new();
         for block in cfg.blocks.values() {
             let mut block_definitions = BTreeSet::new();
+            let mut exceptional_definitions = BTreeSet::new();
             let mut block_uses = BTreeSet::new();
-            for instruction in &block.insns {
+            // Exception successors observe the register state immediately before the
+            // terminal throwing instruction. Its result exists only on normal exit.
+            let exceptional_boundary = cfg
+                .successors_with_kind(block.id)
+                .iter()
+                .any(|(_, kind)| kind.is_exception())
+                .then(|| {
+                    block
+                        .insns
+                        .iter()
+                        .rposition(|instruction| instruction.can_throw())
+                })
+                .flatten();
+            for (index, instruction) in block.insns.iter().enumerate() {
                 let uses = instruction
                     .args
                     .iter()
@@ -36,9 +51,13 @@ impl RegisterLiveness {
                 }
                 if let Some(result) = &instruction.result {
                     block_definitions.insert(result.reg_num);
+                    if exceptional_boundary.is_none_or(|boundary| index < boundary) {
+                        exceptional_definitions.insert(result.reg_num);
+                    }
                 }
             }
             definitions.insert(block.id, block_definitions);
+            definitions_before_exception.insert(block.id, exceptional_definitions);
             upward_uses.insert(block.id, block_uses);
         }
 
@@ -51,13 +70,32 @@ impl RegisterLiveness {
         loop {
             let mut changed = false;
             for block in cfg.block_ids().into_iter().rev() {
-                let output = cfg
-                    .successors(block)
-                    .flat_map(|successor| live_in.get(&successor).into_iter().flatten().copied())
+                let mut normal_output = BTreeSet::new();
+                let mut exceptional_output = BTreeSet::new();
+                for (successor, kind) in cfg.successors_with_kind(block) {
+                    let output = if kind.is_exception() {
+                        &mut exceptional_output
+                    } else {
+                        &mut normal_output
+                    };
+                    output.extend(live_in.get(successor).into_iter().flatten().copied());
+                }
+                let output = normal_output
+                    .union(&exceptional_output)
+                    .copied()
                     .collect::<BTreeSet<_>>();
                 let mut input = upward_uses.get(&block).cloned().unwrap_or_default();
                 let defined = definitions.get(&block).cloned().unwrap_or_default();
-                input.extend(output.difference(&defined).copied());
+                let defined_before_exception = definitions_before_exception
+                    .get(&block)
+                    .cloned()
+                    .unwrap_or_default();
+                input.extend(normal_output.difference(&defined).copied());
+                input.extend(
+                    exceptional_output
+                        .difference(&defined_before_exception)
+                        .copied(),
+                );
                 if live_out.get(&block) != Some(&output) {
                     live_out.insert(block, output);
                     changed = true;

--- a/dexdec/src/ir/analysis/source_variables.rs
+++ b/dexdec/src/ir/analysis/source_variables.rs
@@ -54,14 +54,8 @@ impl SourceVariableAllocation {
         regions: &RegionGraph,
     ) -> Result<Self, SourceVariableError> {
         let contractions = ControlContractions::for_edge_arguments(cfg, regions);
-        let required_phis = RequiredPhiValues::collect(
-            cfg,
-            values,
-            root,
-            constants,
-            recovered_phis,
-            &contractions,
-        )?;
+        let required_phis =
+            RequiredPhiValues::collect(cfg, values, root, constants, &contractions)?;
         let statement_definitions = StatementDefinitions::collect(root);
         let mut cleanup_values = regions
             .cleanup_value_bindings()

--- a/dexdec/src/ir/analysis/source_variables/phi.rs
+++ b/dexdec/src/ir/analysis/source_variables/phi.rs
@@ -505,7 +505,6 @@ impl RequiredPhiValues {
         graph: &SsaValueGraph,
         root: &SemanticNode,
         constants: &BTreeMap<SsaVar, InsnArg>,
-        recovered: &BTreeSet<SsaVar>,
         contractions: &ControlContractions,
     ) -> Result<BTreeSet<SsaVar>, SourceVariableError> {
         let mut collector = Self {
@@ -520,7 +519,13 @@ impl RequiredPhiValues {
         let edge_arguments = ContractedEdgeArguments::new(cfg, graph, constants, contractions);
         while let Some(value) = pending.pop() {
             if !visited.insert(value)
-                || (recovered.contains(&value) && materialized.contains(&value))
+                // A semantic statement owns its rewritten dependencies. In
+                // particular, gated value recovery can replace a CFG move
+                // from a Phi with a Select expression while retaining the
+                // move's result identity. Following the stale CFG operand
+                // would lower that already-recovered Phi a second time and
+                // place copies before the Select's branch definitions.
+                || materialized.contains(&value)
                 || PhiCopies::canonical_constant(constants, value).is_some()
             {
                 continue;
@@ -2835,6 +2840,67 @@ mod tests {
             PhiTypeResolver::new(&cfg, &values, &types, &constants, &hierarchy, &resolved);
 
         assert_eq!(resolver.physical_type(moved_value), Some(ArgType::BOOLEAN));
+    }
+
+    #[test]
+    fn semantic_select_definition_does_not_rematerialize_its_cfg_phi() {
+        let entry = BlockId::new(0);
+        let left_block = BlockId::new(1);
+        let right_block = BlockId::new(2);
+        let join = BlockId::new(3);
+        let left = RegisterArg::new_ssa(1, 0, ArgType::INT);
+        let right = RegisterArg::new_ssa(1, 1, ArgType::INT);
+        let phi_result = RegisterArg::new_ssa(1, 2, ArgType::INT);
+        let moved = RegisterArg::new_ssa(3, 0, ArgType::INT);
+        let phi_value = SsaVar::from_reg(&phi_result).expect("phi SSA value");
+
+        let mut cfg = CFG::new("recovered_select_move");
+        cfg.entry = entry;
+        cfg.add_block(Block::new(entry));
+        let mut left_body = Block::new(left_block);
+        left_body.push(InsnNode::const_value(left.clone(), 1));
+        cfg.add_block(left_body);
+        let mut right_body = Block::new(right_block);
+        right_body.push(InsnNode::const_value(right.clone(), 2));
+        cfg.add_block(right_body);
+        let mut join_body = Block::new(join);
+        join_body.push(InsnNode::phi(
+            phi_result.clone(),
+            vec![
+                (left_block.raw(), InsnArg::Reg(left.clone())),
+                (right_block.raw(), InsnArg::Reg(right.clone())),
+            ],
+        ));
+        join_body.push(InsnNode::move_insn(moved.clone(), InsnArg::Reg(phi_result)));
+        cfg.add_block(join_body);
+        cfg.add_edge(entry, left_block, EdgeKind::True);
+        cfg.add_edge(entry, right_block, EdgeKind::False);
+        cfg.add_edge(left_block, join, EdgeKind::Normal);
+        cfg.add_edge(right_block, join, EdgeKind::Normal);
+
+        let values = SsaValueGraph::build(&cfg).expect("SSA graph");
+        let root = SemanticNode::BasicBlock(SemanticBlock {
+            id: join,
+            statements: vec![SemanticStatement::definition(
+                InstructionId::new(7),
+                moved,
+                SemanticExpression::select(
+                    crate::ir::SemanticPredicate::True,
+                    SemanticExpression::Register(left),
+                    SemanticExpression::Register(right),
+                ),
+            )],
+        });
+        let required = RequiredPhiValues::collect(
+            &cfg,
+            &values,
+            &root,
+            &BTreeMap::new(),
+            &ControlContractions::identity(),
+        )
+        .expect("required Phi analysis");
+
+        assert!(!required.contains(&phi_value));
     }
 
     #[test]

--- a/dexdec/src/ir/cfg.rs
+++ b/dexdec/src/ir/cfg.rs
@@ -561,6 +561,14 @@ impl CFG {
         self.preds_dirty = true;
     }
 
+    /// Remove one typed edge while preserving parallel edges with a different kind.
+    pub fn remove_edge_with_kind(&mut self, from: BlockId, to: BlockId, kind: EdgeKind) {
+        if let Some(successors) = self.successors.get_mut(&from) {
+            successors.retain(|edge| *edge != (to, kind));
+        }
+        self.preds_dirty = true;
+    }
+
     /// Get the kind of edge between two blocks, if it exists.
     pub fn get_edge_kind(&self, from: BlockId, to: BlockId) -> Option<EdgeKind> {
         self.successors

--- a/dexdec/src/ir/exception.rs
+++ b/dexdec/src/ir/exception.rs
@@ -3144,7 +3144,7 @@ impl HandlerSemanticDomains {
                 })
             })
             .collect::<BTreeSet<_>>();
-        let domains = entries
+        let mut domains = entries
             .iter()
             .copied()
             .map(|entry| {
@@ -3183,8 +3183,96 @@ impl HandlerSemanticDomains {
                     },
                 )
             })
-            .collect();
+            .collect::<BTreeMap<_, _>>();
+        Self::bridge_monitor_split_handlers(cfg, &entries, &entry_clauses, &mut domains);
         Self { domains }
+    }
+
+    /// Rejoins the two physical catches produced when javac/d8 lowers an outer
+    /// catch around a synchronized statement. Exceptions thrown while acquiring
+    /// the monitor enter one adapter, while exceptions rethrown after monitor
+    /// cleanup enter another; both adapters merge the caught exception and live
+    /// local state into the same source-level catch body.
+    fn bridge_monitor_split_handlers(
+        cfg: &CFG,
+        entries: &BTreeSet<BlockId>,
+        entry_clauses: &HandlerEntryClauses,
+        domains: &mut BTreeMap<BlockId, HandlerSemanticDomain>,
+    ) {
+        let mut bridges = Vec::new();
+        for entry in entries {
+            let Some(domain) = domains.get(entry) else {
+                continue;
+            };
+            if domain.canonical_entry != *entry {
+                continue;
+            }
+            let enters_from_monitor =
+                cfg.incoming_edges(*entry)
+                    .into_iter()
+                    .any(|(predecessor, kind)| {
+                        kind.is_exception()
+                            && cfg.block(predecessor).is_some_and(|block| {
+                                block.insns.iter().any(|instruction| {
+                                    instruction.insn_type == InsnType::MonitorEnter
+                                })
+                            })
+                    });
+            if !enters_from_monitor {
+                continue;
+            }
+
+            let successors = cfg
+                .normal_successors(*entry)
+                .filter(|successor| domain.blocks.contains(successor))
+                .collect::<Vec<_>>();
+            let [successor] = successors.as_slice() else {
+                continue;
+            };
+            let has_compatible_peer = entry_clauses
+                .compatible_with(*entry)
+                .into_iter()
+                .filter(|peer| peer != entry)
+                .any(|peer| {
+                    domains
+                        .get(&peer)
+                        .is_some_and(|peer_domain| peer_domain.canonical_entry == *successor)
+                });
+            if !has_compatible_peer {
+                continue;
+            }
+
+            let Some(caught) = cfg.block(*entry).and_then(|block| {
+                block.insns.iter().find_map(|instruction| {
+                    (instruction.insn_type == InsnType::MoveException)
+                        .then(|| instruction.result.as_ref().and_then(SsaVar::from_reg))
+                        .flatten()
+                })
+            }) else {
+                continue;
+            };
+            let exception_flow = HandlerSemantics::exception_flow(cfg, &domain.blocks, caught);
+            let Some(entry_block) = cfg.block(*entry) else {
+                continue;
+            };
+            let Some(successor_block) = cfg.block(*successor) else {
+                continue;
+            };
+            if HandlerAdapterEffects::forwards_state_to_phis(
+                entry_block,
+                successor_block,
+                &exception_flow,
+            ) {
+                bridges.push((*entry, *successor));
+            }
+        }
+
+        for (entry, successor) in bridges {
+            if let Some(domain) = domains.get_mut(&entry) {
+                domain.adapter_blocks.insert(entry);
+                domain.canonical_entry = successor;
+            }
+        }
     }
 
     fn domain(&self, entry: BlockId) -> HandlerSemanticDomain {
@@ -3460,6 +3548,45 @@ impl HandlerAdapterEffects {
                 && instruction.insn_type != InsnType::Const
         });
         forwards_exception && reaches_semantics
+    }
+
+    fn forwards_state_to_phis(
+        block: &super::Block,
+        successor: &super::Block,
+        exception_flow: &BTreeSet<SsaVar>,
+    ) -> bool {
+        if !block.insns.iter().all(|instruction| {
+            InstructionEffects::is_ssa_bookkeeping(instruction)
+                || instruction.insn_type == InsnType::Const
+        }) {
+            return false;
+        }
+        let forwarded = block
+            .insns
+            .iter()
+            .filter(|instruction| instruction.insn_type != InsnType::MoveException)
+            .filter_map(|instruction| instruction.result.as_ref().and_then(SsaVar::from_reg))
+            .collect::<BTreeSet<_>>();
+        if forwarded.is_empty() || forwarded.is_disjoint(exception_flow) {
+            return false;
+        }
+
+        let is_phi_argument = |value: SsaVar| {
+            successor.insns.iter().any(|instruction| {
+                instruction.insn_type == InsnType::Phi
+                    && instruction
+                        .args
+                        .iter()
+                        .filter_map(InsnArg::as_register)
+                        .filter_map(SsaVar::from_reg)
+                        .any(|argument| argument == value)
+            })
+        };
+        let reaches_semantics = successor.insns.iter().any(|instruction| {
+            !InstructionEffects::is_ssa_bookkeeping(instruction)
+                && instruction.insn_type != InsnType::Const
+        });
+        forwarded.iter().copied().all(is_phi_argument) && reaches_semantics
     }
 }
 
@@ -4153,7 +4280,7 @@ impl<'a> FiniteExitAnalysis<'a> {
 mod tests {
     use super::*;
     use crate::ir::analysis::ClassHierarchyIndex;
-    use crate::ir::{Block, InsnNode};
+    use crate::ir::{Block, ExceptionHandler, InsnNode};
 
     fn exception_hierarchy() -> ClassHierarchyIndex {
         let mut hierarchy = ClassHierarchyIndex::default();
@@ -4510,6 +4637,102 @@ mod tests {
             continuation.adapters,
             BTreeSet::from([BlockId::new(0), BlockId::new(1)])
         );
+    }
+
+    fn split_handler_domains(enters_monitor: bool) -> HandlerSemanticDomains {
+        let mut cfg = CFG::new("monitor_split_handler");
+        let lock = RegisterArg::new_ssa(0, 0, ArgType::object("java/lang/Object"));
+        let caught_at_enter = RegisterArg::new_ssa(1, 0, ArgType::throwable());
+        let forwarded_exception = RegisterArg::new_ssa(1, 1, ArgType::throwable());
+        let caught_after_cleanup = RegisterArg::new_ssa(1, 2, ArgType::throwable());
+        let canonical_exception = RegisterArg::new_ssa(1, 3, ArgType::throwable());
+        let initial_state = RegisterArg::new_ssa(2, 0, ArgType::string());
+        let forwarded_state = RegisterArg::new_ssa(2, 1, ArgType::string());
+        let canonical_state = RegisterArg::new_ssa(2, 2, ArgType::string());
+
+        let mut monitor = Block::new(0);
+        if enters_monitor {
+            monitor.push(InsnNode::monitor_enter(InsnArg::Reg(lock)));
+        } else {
+            monitor.push(InsnNode::new(InsnType::Invoke, 0));
+        }
+        cfg.add_block(monitor);
+        let mut cleanup_rethrow = Block::new(1);
+        cleanup_rethrow.push(InsnNode::throw(InsnArg::reg_ssa(
+            3,
+            0,
+            ArgType::throwable(),
+        )));
+        cfg.add_block(cleanup_rethrow);
+
+        let mut enter_adapter = Block::new(2);
+        enter_adapter.push(InsnNode::move_exception(caught_at_enter.clone()));
+        enter_adapter.push(InsnNode::mov(
+            forwarded_state.clone(),
+            InsnArg::Reg(initial_state),
+        ));
+        enter_adapter.push(InsnNode::mov(
+            forwarded_exception.clone(),
+            InsnArg::Reg(caught_at_enter),
+        ));
+        cfg.add_block(enter_adapter);
+
+        let mut cleanup_adapter = Block::new(3);
+        cleanup_adapter.push(InsnNode::move_exception(caught_after_cleanup.clone()));
+        cfg.add_block(cleanup_adapter);
+
+        let mut catch_body = Block::new(4);
+        catch_body.push(InsnNode::phi(
+            canonical_exception,
+            vec![
+                (2, InsnArg::Reg(forwarded_exception)),
+                (3, InsnArg::Reg(caught_after_cleanup)),
+            ],
+        ));
+        catch_body.push(InsnNode::phi(
+            canonical_state,
+            vec![(2, InsnArg::Reg(forwarded_state))],
+        ));
+        catch_body.push(InsnNode::new(InsnType::Invoke, 4));
+        cfg.add_block(catch_body);
+
+        cfg.add_edge(BlockId::new(0), BlockId::new(2), EdgeKind::Exception);
+        cfg.add_edge(BlockId::new(1), BlockId::new(3), EdgeKind::Exception);
+        cfg.add_edge(BlockId::new(2), BlockId::new(4), EdgeKind::Normal);
+        cfg.add_edge(BlockId::new(3), BlockId::new(4), EdgeKind::Normal);
+        let catch_type = Some(ArgType::object("java/io/IOException"));
+        cfg.handlers
+            .push(ExceptionHandler::new(0, 1, 2, catch_type.clone()));
+        cfg.handlers
+            .push(ExceptionHandler::new(1, 2, 3, catch_type));
+
+        let entries = BTreeMap::from([(2, BlockId::new(2)), (3, BlockId::new(3))]);
+        HandlerSemanticDomains::analyze(&cfg, &entries)
+    }
+
+    #[test]
+    fn rejoins_catch_split_around_monitor_cleanup() {
+        let domains = split_handler_domains(true);
+
+        let enter_domain = domains.domain(BlockId::new(2));
+        assert_eq!(enter_domain.canonical_entry, BlockId::new(4));
+        assert_eq!(
+            enter_domain.adapter_blocks,
+            BTreeSet::from([BlockId::new(2)])
+        );
+        assert_eq!(
+            domains.domain(BlockId::new(3)).canonical_entry,
+            BlockId::new(4)
+        );
+    }
+
+    #[test]
+    fn ordinary_catch_state_transfer_remains_semantic() {
+        let domains = split_handler_domains(false);
+
+        let enter_domain = domains.domain(BlockId::new(2));
+        assert_eq!(enter_domain.canonical_entry, BlockId::new(2));
+        assert!(enter_domain.adapter_blocks.is_empty());
     }
 
     #[test]

--- a/dexdec/src/ir/passes/recover_constructors.rs
+++ b/dexdec/src/ir/passes/recover_constructors.rs
@@ -610,21 +610,13 @@ impl Pass for RecoverConstructors<'_> {
         let mut exceptional_merges = facts
             .discarded_allocations()
             .iter()
-            .map(|allocation| {
-                let successors = cfg.successors_with_kind(allocation.block);
-                ExceptionalAllocationMerge {
-                    allocation: allocation.block,
-                    handlers: successors
-                        .iter()
-                        .filter_map(|(target, kind)| {
-                            (*kind == EdgeKind::Exception
-                                && !successors.iter().any(|(normal_target, normal_kind)| {
-                                    normal_target == target && *normal_kind != EdgeKind::Exception
-                                }))
-                            .then_some(*target)
-                        })
-                        .collect(),
-                }
+            .map(|allocation| ExceptionalAllocationMerge {
+                allocation: allocation.block,
+                handlers: cfg
+                    .successors_with_kind(allocation.block)
+                    .iter()
+                    .filter_map(|(target, kind)| (*kind == EdgeKind::Exception).then_some(*target))
+                    .collect(),
             })
             .collect::<Vec<_>>();
         let mut versions = SyntheticVersions::new(&values);
@@ -759,7 +751,7 @@ struct ExceptionalAllocationMerge {
 impl ExceptionalAllocationMerge {
     fn apply(self, cfg: &mut CFG) -> Result<(), ConstructorRecoveryError> {
         for handler in self.handlers {
-            cfg.remove_edge(self.allocation, handler);
+            cfg.remove_edge_with_kind(self.allocation, handler, EdgeKind::Exception);
             let block = cfg
                 .block_mut(handler)
                 .ok_or(ConstructorRecoveryError::MissingHandler(handler))?;
@@ -884,7 +876,7 @@ mod tests {
     }
 
     #[test]
-    fn discarded_allocation_preserves_shared_normal_and_exception_target() {
+    fn discarded_allocation_removes_exception_edge_to_shared_normal_target() {
         let entry_id = BlockId::new(2);
         let allocation_id = BlockId::new(0);
         let continuation_id = BlockId::new(1);
@@ -930,10 +922,16 @@ mod tests {
 
         assert_eq!(result, PassResult::Changed);
         assert!(cfg.has_edge(allocation_id, continuation_id));
-        assert_eq!(cfg.successors_with_kind(allocation_id).len(), 2);
+        assert_eq!(
+            cfg.successors_with_kind(allocation_id),
+            &[(continuation_id, EdgeKind::Normal)]
+        );
         assert!(cfg.block(allocation_id).unwrap().insns.is_empty());
         let phi = &cfg.block(continuation_id).unwrap().insns[0];
-        assert_eq!(phi.args.len(), 2);
-        assert_eq!(phi.payload.phi_edges.len(), 2);
+        assert_eq!(phi.args.len(), 1);
+        assert_eq!(
+            phi.payload.phi_edges,
+            vec![(allocation_id, EdgeKind::Normal)]
+        );
     }
 }

--- a/dexdec/src/ir/passes/ssa_transform.rs
+++ b/dexdec/src/ir/passes/ssa_transform.rs
@@ -951,4 +951,78 @@ mod tests {
             phi.result.as_ref().unwrap().ssa_version
         );
     }
+
+    #[test]
+    fn throwing_result_preserves_prior_phi_on_exception_edge() {
+        let mut cfg = CFG::new("exception_result_after_join");
+        cfg.registers = 1;
+        cfg.ins = 0;
+        cfg.set_method(MethodContext::new(
+            ArgType::object("Owner"),
+            "call",
+            MethodDescriptor {
+                parameters: Vec::new(),
+                return_type: ArgType::INT,
+            },
+            true,
+        ));
+
+        cfg.add_block(Block::new(0u32));
+        let mut left = Block::new(1u32);
+        left.push(InsnNode::const_value(RegisterArg::new(0, ArgType::INT), 1));
+        cfg.add_block(left);
+        let mut right = Block::new(2u32);
+        right.push(InsnNode::const_value(RegisterArg::new(0, ArgType::INT), 2));
+        cfg.add_block(right);
+
+        let mut throwing = Block::new(3u32);
+        let mut invoke = InsnNode::new(InsnType::Invoke, 0);
+        invoke.set_result(RegisterArg::new(0, ArgType::INT));
+        throwing.push(invoke);
+        cfg.add_block(throwing);
+        let mut handler = Block::new(4u32);
+        handler.push(InsnNode::ret(Some(InsnArg::reg(0, ArgType::INT))));
+        cfg.add_block(handler);
+        let mut normal = Block::new(5u32);
+        normal.push(InsnNode::ret(Some(InsnArg::reg(0, ArgType::INT))));
+        cfg.add_block(normal);
+
+        cfg.add_edge(BlockId(0), BlockId(1), EdgeKind::Normal);
+        cfg.add_edge(BlockId(0), BlockId(2), EdgeKind::Normal);
+        cfg.add_edge(BlockId(1), BlockId(3), EdgeKind::Normal);
+        cfg.add_edge(BlockId(2), BlockId(3), EdgeKind::Normal);
+        cfg.add_edge(BlockId(3), BlockId(4), EdgeKind::Exception);
+        cfg.add_edge(BlockId(3), BlockId(5), EdgeKind::Normal);
+        cfg.entry = BlockId(0);
+
+        SSATransform.run(&mut cfg).unwrap();
+
+        let throwing = cfg.block(BlockId(3)).unwrap();
+        let prior = throwing
+            .insns
+            .iter()
+            .find(|instruction| instruction.insn_type == InsnType::Phi)
+            .and_then(|phi| phi.result.as_ref())
+            .and_then(|result| result.ssa_version)
+            .expect("joined value before throwing invoke");
+        let invoke_result = throwing
+            .insns
+            .last()
+            .and_then(|invoke| invoke.result.as_ref())
+            .and_then(|result| result.ssa_version)
+            .expect("normal invoke result");
+        let exceptional = cfg
+            .block(BlockId(4))
+            .unwrap()
+            .insns
+            .iter()
+            .find(|instruction| instruction.insn_type == InsnType::Phi)
+            .and_then(|phi| phi.args.first())
+            .and_then(InsnArg::as_register)
+            .and_then(|argument| argument.ssa_version)
+            .expect("exception edge value");
+
+        assert_eq!(exceptional, prior);
+        assert_ne!(exceptional, invoke_result);
+    }
 }

--- a/dexdec/src/ir/region.rs
+++ b/dexdec/src/ir/region.rs
@@ -225,7 +225,10 @@ impl RegionTransfer {
             RegionExitKind::Return => true,
             RegionExitKind::Break => true,
             RegionExitKind::Continue => true,
-            RegionExitKind::Throw => false,
+            // Ordinary throw instructions have no normal transfer. A Throw
+            // transfer denotes a proven cleanup adapter whose physical edge
+            // enters an enclosing finally before rethrowing.
+            RegionExitKind::Throw => self.kind == RegionTransferKind::Leave,
         }
     }
 }

--- a/dexdec/src/ir/region/builder.rs
+++ b/dexdec/src/ir/region/builder.rs
@@ -204,6 +204,8 @@ impl<'a> RegionGraphBuilder<'a> {
             &mut exception_handlers,
         )?;
         ExceptionRegionCanonicalizer::apply(
+            analysis,
+            cfg,
             &mut tree,
             &mut exception_region_map,
             &mut exception_handlers,

--- a/dexdec/src/ir/region/builder.rs
+++ b/dexdec/src/ir/region/builder.rs
@@ -180,13 +180,7 @@ impl<'a> RegionGraphBuilder<'a> {
                     .extend(inherited);
             }
             for handlers in exception_handlers.values_mut() {
-                for handler in handlers.iter_mut() {
-                    if removed.contains(handler) {
-                        *handler = region_id;
-                    }
-                }
-                handlers.sort();
-                handlers.dedup();
+                remap_removed_handlers(handlers, &removed, region_id);
             }
             elisions.insert_source_equivalent(fact.enter_origin);
             elisions.extend_source_equivalent(fact.release_origins);
@@ -262,6 +256,41 @@ impl<'a> RegionGraphBuilder<'a> {
         };
         graph.verify(cfg)?;
         Ok(graph)
+    }
+}
+
+fn remap_removed_handlers(
+    handlers: &mut Vec<RegionId>,
+    removed: &BTreeSet<RegionId>,
+    replacement: RegionId,
+) {
+    for handler in handlers.iter_mut() {
+        if removed.contains(handler) {
+            *handler = replacement;
+        }
+    }
+    // Catch order comes from the DEX handler table. Region ids only reflect
+    // construction order, so sorting here can move a catch-all before typed
+    // catches and make the emitted Java clauses unreachable.
+    let mut seen = BTreeSet::new();
+    handlers.retain(|handler| seen.insert(*handler));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synchronization_handler_remapping_preserves_catch_order() {
+        let typed = RegionId::new(6);
+        let broader_typed = RegionId::new(7);
+        let catch_all = RegionId::new(2);
+        let removed = RegionId::new(8);
+        let mut handlers = vec![typed, broader_typed, catch_all, removed];
+
+        remap_removed_handlers(&mut handlers, &BTreeSet::from([removed]), broader_typed);
+
+        assert_eq!(handlers, vec![typed, broader_typed, catch_all]);
     }
 }
 

--- a/dexdec/src/ir/region/exceptions.rs
+++ b/dexdec/src/ir/region/exceptions.rs
@@ -1724,10 +1724,9 @@ impl<'a> ExceptionRegionTreeBuilder<'a> {
             .cloned()
             .unwrap_or_default()
         {
-            let merged_kind = self
-                .tree
-                .region(region)
-                .and_then(|existing| Self::merge_handler_kind(&existing.kind, kind));
+            let merged_kind = self.tree.region(region).and_then(|existing| {
+                Self::merge_handler_kind(&existing.kind, kind, existing.blocks == *blocks)
+            });
             let Some(merged_kind) = merged_kind else {
                 continue;
             };
@@ -1754,7 +1753,7 @@ impl<'a> ExceptionRegionTreeBuilder<'a> {
                     .region(region)
                     .ok_or(RegionInvariantError::UnknownRegion(region))?;
                 (existing.blocks == *blocks)
-                    .then(|| Self::merge_handler_kind(&existing.kind, kind))
+                    .then(|| Self::merge_handler_kind(&existing.kind, kind, true))
                     .flatten()
             };
             let Some(merged_kind) = merged_kind else {
@@ -1769,16 +1768,36 @@ impl<'a> ExceptionRegionTreeBuilder<'a> {
         Ok(None)
     }
 
-    fn merge_handler_kind(left: &RegionKind, right: &RegionKind) -> Option<RegionKind> {
+    fn merge_handler_kind(
+        left: &RegionKind,
+        right: &RegionKind,
+        same_component: bool,
+    ) -> Option<RegionKind> {
         match (left, right) {
             (RegionKind::Finally, RegionKind::Finally)
             | (RegionKind::Finally, RegionKind::Cleanup(_))
             | (RegionKind::Cleanup(_), RegionKind::Finally) => Some(RegionKind::Finally),
-            (RegionKind::Catch(left), RegionKind::Catch(right)) => (left.exception_types
-                == right.exception_types
-                && left.exception_value == right.exception_value
-                && left.continuation == right.continuation)
-                .then(|| RegionKind::Catch(left.clone())),
+            (RegionKind::Catch(left), RegionKind::Catch(right))
+                if left.exception_types == right.exception_types
+                    && left.exception_value == right.exception_value =>
+            {
+                let continuation = match (left.continuation, right.continuation) {
+                    (left, right) if left == right => left,
+                    // DEX may route nested fallback catches to the same
+                    // physical body. A protection-relative analysis can see
+                    // the body's ordinary re-entry as a continuation for one
+                    // range but not the other. Identical owned components
+                    // prove that the present continuation is the shared
+                    // lexical boundary rather than context-specific code.
+                    (Some(continuation), None) | (None, Some(continuation)) if same_component => {
+                        Some(continuation)
+                    }
+                    _ => return None,
+                };
+                let mut merged = left.clone();
+                merged.continuation = continuation;
+                Some(RegionKind::Catch(merged))
+            }
             (RegionKind::Cleanup(left), RegionKind::Cleanup(right)) => (left.exception_types
                 == right.exception_types
                 && left.exception_value == right.exception_value
@@ -2422,6 +2441,38 @@ mod tests {
             .expect("shared-suffix nesting");
 
         assert_eq!(builder.tree.region(fragment).unwrap().parent, Some(root));
+    }
+
+    #[test]
+    fn same_catch_component_preserves_present_continuation() {
+        let continuation = BlockId::new(7);
+        let catch = |continuation| {
+            RegionKind::Catch(CatchRegion {
+                exception_types: vec![crate::ir::ArgType::object("java/lang/NoSuchFieldException")],
+                exception_value: None,
+                continuation,
+            })
+        };
+
+        let merged = ExceptionRegionTreeBuilder::merge_handler_kind(
+            &catch(Some(continuation)),
+            &catch(None),
+            true,
+        )
+        .expect("same physical catch component");
+        assert!(matches!(
+            merged,
+            RegionKind::Catch(CatchRegion {
+                continuation: Some(actual),
+                ..
+            }) if actual == continuation
+        ));
+        assert!(ExceptionRegionTreeBuilder::merge_handler_kind(
+            &catch(Some(continuation)),
+            &catch(None),
+            false,
+        )
+        .is_none());
     }
 
     #[test]

--- a/dexdec/src/ir/region/exceptions.rs
+++ b/dexdec/src/ir/region/exceptions.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ir::analysis::ControlFlowFacts;
-use crate::ir::exception::{CatchHandler, ExceptionAnalysis, HandlerKind};
+use crate::ir::exception::{CatchHandler, CleanupProofOutcome, ExceptionAnalysis, HandlerKind};
 use crate::ir::{Block, BlockId, StatementOrigin, CFG};
 
 use super::{CatchRegion, RegionId, RegionInvariantError, RegionKind, RegionPlacement, RegionTree};
@@ -26,10 +26,13 @@ pub(super) struct ExceptionRegionCanonicalizer;
 
 impl ExceptionRegionCanonicalizer {
     pub(super) fn apply(
+        analysis: &ExceptionAnalysis,
+        cfg: &CFG,
         tree: &mut RegionTree,
         mapping: &mut BTreeMap<u32, Vec<RegionId>>,
         handlers: &mut BTreeMap<RegionId, Vec<RegionId>>,
     ) -> Result<(), RegionInvariantError> {
+        Self::coalesce_finally_families(analysis, cfg, tree, handlers)?;
         for regions in mapping.values_mut() {
             regions.sort_unstable();
             regions.dedup();
@@ -54,6 +57,154 @@ impl ExceptionRegionCanonicalizer {
                 .map(|(_, region)| region)
                 .collect::<BTreeSet<_>>();
             regions.retain(|region| !removed.contains(region));
+        }
+        Ok(())
+    }
+
+    /// DEX cannot overlap protected intervals, so javac/d8 split one lexical
+    /// try/finally around nested catches and their handler bodies. When those
+    /// intervals share one proven source-finally handler, recover the outer
+    /// scope before semantic reduction. The proven normal cleanup copy is the
+    /// lexical exit and must remain outside the recovered try body.
+    fn coalesce_finally_families(
+        analysis: &ExceptionAnalysis,
+        cfg: &CFG,
+        tree: &mut RegionTree,
+        handlers: &mut BTreeMap<RegionId, Vec<RegionId>>,
+    ) -> Result<(), RegionInvariantError> {
+        let finally_regions = tree
+            .regions()
+            .filter(|region| matches!(&region.kind, RegionKind::Finally))
+            .map(|region| region.id)
+            .collect::<Vec<_>>();
+        for finally in finally_regions {
+            let Some(finally_entry) = tree
+                .region(finally)
+                .ok_or(RegionInvariantError::UnknownRegion(finally))?
+                .entry
+            else {
+                continue;
+            };
+            let sources = analysis
+                .regions
+                .iter()
+                .filter_map(|source| {
+                    let cleanup = source.handlers.iter().find(|handler| {
+                        handler.kind != HandlerKind::Catch
+                            && handler.semantic_entry == finally_entry
+                    })?;
+                    Some((source, cleanup))
+                })
+                .collect::<Vec<_>>();
+            if sources.len() < 2 {
+                continue;
+            }
+
+            let mut owners = handlers
+                .iter()
+                .filter_map(|(owner, owned)| owned.contains(&finally).then_some(*owner))
+                .collect::<BTreeSet<_>>();
+            if owners.len() < 2 {
+                continue;
+            }
+            let normal_exits = analysis
+                .cleanup_proofs
+                .iter()
+                .filter(|proof| proof.outcome == CleanupProofOutcome::Proven)
+                .filter(|proof| {
+                    sources.iter().any(|(source, cleanup)| {
+                        source.id == proof.region && cleanup.id == proof.handler
+                    })
+                })
+                .map(|proof| proof.normal_entry)
+                .collect::<BTreeSet<_>>();
+            if normal_exits.is_empty() {
+                continue;
+            }
+            let final_component = sources
+                .iter()
+                .flat_map(|(_, handler)| {
+                    handler
+                        .entry_blocks
+                        .iter()
+                        .chain(&handler.adapter_blocks)
+                        .chain(&handler.blocks)
+                        .chain(&handler.semantic_blocks)
+                        .chain(&handler.rethrow_blocks)
+                        .copied()
+                        .chain([
+                            handler.handler_block,
+                            handler.semantic_entry,
+                            handler.canonical_entry,
+                        ])
+                })
+                .collect::<BTreeSet<_>>();
+
+            while owners.len() > 1 {
+                let Some(start) = owners
+                    .iter()
+                    .copied()
+                    .filter_map(|owner| {
+                        let entry = tree.region(owner)?.entry?;
+                        let offset = cfg
+                            .block(entry)
+                            .map(|block| block.offset)
+                            .unwrap_or(u32::MAX);
+                        Some((offset, entry, owner))
+                    })
+                    .min()
+                else {
+                    break;
+                };
+                let (_, entry, first_owner) = start;
+                let mut domain = BTreeSet::new();
+                let mut pending = vec![entry];
+                while let Some(block) = pending.pop() {
+                    if normal_exits.contains(&block)
+                        || final_component.contains(&block)
+                        || !domain.insert(block)
+                    {
+                        continue;
+                    }
+                    pending.extend(
+                        cfg.successors_with_kind(block)
+                            .iter()
+                            .map(|(target, _)| *target),
+                    );
+                }
+                let members = owners
+                    .iter()
+                    .copied()
+                    .filter(|owner| {
+                        tree.region(*owner)
+                            .and_then(|region| region.entry)
+                            .is_some_and(|entry| domain.contains(&entry))
+                    })
+                    .collect::<BTreeSet<_>>();
+                if members.len() < 2 {
+                    owners.remove(&first_owner);
+                    continue;
+                }
+                domain = tree.laminar_closure(&domain);
+                if !normal_exits.is_disjoint(&domain) || !final_component.is_disjoint(&domain) {
+                    owners.remove(&first_owner);
+                    continue;
+                }
+                let synthetic = match tree.insert_laminar_region(RegionKind::Try, entry, domain)? {
+                    RegionPlacement::Inserted(region) => region,
+                    RegionPlacement::Residual => {
+                        owners.remove(&first_owner);
+                        continue;
+                    }
+                };
+                handlers.insert(synthetic, vec![finally]);
+                for member in &members {
+                    if let Some(owned) = handlers.get_mut(member) {
+                        owned.retain(|handler| *handler != finally);
+                    }
+                }
+                owners.retain(|owner| !members.contains(owner));
+            }
         }
         Ok(())
     }
@@ -1151,6 +1302,13 @@ impl<'a> ExceptionRegionTreeBuilder<'a> {
             .map(|(_, entry)| *entry)
             .collect::<BTreeSet<_>>();
         if entries.len() != 1 {
+            // A protected range in a shared handler suffix can be contained
+            // by several lexical catch domains with different entries. None
+            // of those catches is a unique source-level owner; preserve the
+            // explicit exception-table parent when one exists.
+            if let Some(parent) = source.parent {
+                return Ok(ExceptionParent::Try(parent));
+            }
             return Err(RegionInvariantError::AmbiguousExceptionHandlerParent {
                 region: source.id,
                 handlers: minimal,
@@ -1408,9 +1566,45 @@ impl<'a> ExceptionRegionTreeBuilder<'a> {
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             candidates.sort();
-            let Some((_, _, owner)) = candidates.first().copied() else {
+            let Some((domain_size, depth, owner)) = candidates.first().copied() else {
                 continue;
             };
+            let equally_specific = candidates
+                .iter()
+                .take_while(|(candidate_size, candidate_depth, _)| {
+                    *candidate_size == domain_size && *candidate_depth == depth
+                })
+                .map(|(_, _, handler)| *handler)
+                .collect::<Vec<_>>();
+            if equally_specific.len() > 1 {
+                // This fragment is a suffix shared by several sibling
+                // handlers, not the lexical body of whichever handler happens
+                // to have the smallest RegionId. Since handlers are added
+                // incrementally, undo an earlier provisional placement under
+                // one of the now-tied candidates. Preserve an unrelated
+                // explicit parent, which can still be more specific than the
+                // handlers' common ancestor.
+                let nested_in_candidate = equally_specific
+                    .iter()
+                    .copied()
+                    .map(|handler| self.tree.is_ancestor(handler, current))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .any(|nested| nested);
+                if nested_in_candidate {
+                    let common = equally_specific
+                        .iter()
+                        .copied()
+                        .skip(1)
+                        .try_fold(equally_specific[0], |common, handler| {
+                            self.tree.common_ancestor(common, handler)
+                        })?;
+                    if current != common {
+                        self.tree.reparent(fragment, common)?;
+                    }
+                }
+                continue;
+            }
             if current == owner || self.tree.is_ancestor(owner, current)? {
                 continue;
             }
@@ -1881,6 +2075,7 @@ impl<'a> SingleEntryTryFragments<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::exception::CleanupProofDiagnostic;
     use crate::ir::{Block, EdgeKind, HandlerKind, InsnNode, InsnType};
 
     fn catch_handler(entry: BlockId, adapters: impl IntoIterator<Item = BlockId>) -> CatchHandler {
@@ -1902,6 +2097,103 @@ mod tests {
             rethrow_blocks: BTreeSet::new(),
             kind: HandlerKind::Catch,
         }
+    }
+
+    fn finally_handler(entry: BlockId) -> CatchHandler {
+        let mut handler = catch_handler(entry, []);
+        handler.catch_type = None;
+        handler.kind = HandlerKind::Finally;
+        handler
+    }
+
+    #[test]
+    fn proven_split_finally_family_recovers_one_outer_try() {
+        let entry = BlockId::new(0);
+        let first_entry = BlockId::new(1);
+        let second_entry = BlockId::new(2);
+        let normal_cleanup = BlockId::new(3);
+        let finally_entry = BlockId::new(4);
+        let mut cfg = CFG::new("split_finally_family");
+        cfg.entry = entry;
+        for block in [
+            entry,
+            first_entry,
+            second_entry,
+            normal_cleanup,
+            finally_entry,
+        ] {
+            cfg.add_block(Block::new(block));
+        }
+        cfg.add_edge(entry, first_entry, EdgeKind::Normal);
+        cfg.add_edge(first_entry, second_entry, EdgeKind::Normal);
+        cfg.add_edge(second_entry, normal_cleanup, EdgeKind::Normal);
+        cfg.add_edge(first_entry, finally_entry, EdgeKind::Exception);
+        cfg.add_edge(second_entry, finally_entry, EdgeKind::Exception);
+
+        let mut tree = RegionTree::new(Some(entry));
+        tree.cover_method(&cfg).expect("method ownership");
+        let root = tree.root();
+        let first = tree
+            .add_child(root, RegionKind::Try, Some(first_entry))
+            .expect("first split try");
+        tree.add_block(first, first_entry).expect("first try block");
+        let second = tree
+            .add_child(root, RegionKind::Try, Some(second_entry))
+            .expect("second split try");
+        tree.add_block(second, second_entry)
+            .expect("second try block");
+        let finally = tree
+            .add_child(root, RegionKind::Finally, Some(finally_entry))
+            .expect("shared finally");
+        tree.add_block(finally, finally_entry)
+            .expect("finally block");
+
+        let source = |id, block: BlockId| crate::ir::exception::TryRegion {
+            id,
+            start_offset: block.raw(),
+            end_offset: block.raw() + 1,
+            blocks: vec![block],
+            handlers: vec![finally_handler(finally_entry)],
+            parent: None,
+            children: Vec::new(),
+            normal_exit_blocks: vec![normal_cleanup],
+        };
+        let analysis = ExceptionAnalysis {
+            regions: vec![source(10, first_entry), source(11, second_entry)],
+            cleanup_proofs: vec![CleanupProofDiagnostic {
+                region: 10,
+                handler: finally_entry.raw(),
+                normal_entry: normal_cleanup,
+                candidate: normal_cleanup,
+                outcome: CleanupProofOutcome::Proven,
+                mismatch: None,
+            }],
+            ..ExceptionAnalysis::default()
+        };
+        let mut handlers = BTreeMap::from([(first, vec![finally]), (second, vec![finally])]);
+
+        ExceptionRegionCanonicalizer::coalesce_finally_families(
+            &analysis,
+            &cfg,
+            &mut tree,
+            &mut handlers,
+        )
+        .expect("finally family coalescing");
+
+        let synthetic = tree.region(first).unwrap().parent.unwrap();
+        assert_ne!(synthetic, root);
+        assert_eq!(tree.region(second).unwrap().parent, Some(synthetic));
+        assert!(matches!(
+            tree.region(synthetic).unwrap().kind,
+            RegionKind::Try
+        ));
+        assert_eq!(
+            tree.region(synthetic).unwrap().blocks,
+            BTreeSet::from([first_entry, second_entry])
+        );
+        assert_eq!(handlers.get(&synthetic), Some(&vec![finally]));
+        assert!(handlers.get(&first).is_some_and(Vec::is_empty));
+        assert!(handlers.get(&second).is_some_and(Vec::is_empty));
     }
 
     #[test]
@@ -1978,6 +2270,158 @@ mod tests {
                 .expect("cleanup component"),
             BTreeSet::from([handler_entry])
         );
+    }
+
+    #[test]
+    fn explicit_try_parent_owns_a_suffix_shared_by_multiple_handlers() {
+        let entry = BlockId::new(0);
+        let mut cfg = CFG::new("shared_handler_suffix_parent");
+        cfg.add_block(Block::new(entry.raw()));
+        let facts = ControlFlowFacts::analyze(&cfg).expect("control-flow facts");
+
+        let shared = [BlockId::new(104), BlockId::new(105)];
+        let owner = |id, handler_entry| {
+            let mut handler = catch_handler(handler_entry, []);
+            handler.lexical_blocks = std::iter::once(handler_entry).chain(shared).collect();
+            crate::ir::exception::TryRegion {
+                id,
+                start_offset: id,
+                end_offset: id + 1,
+                blocks: vec![BlockId::new(id)],
+                handlers: vec![handler],
+                parent: None,
+                children: Vec::new(),
+                normal_exit_blocks: Vec::new(),
+            }
+        };
+        let explicit_parent = crate::ir::exception::TryRegion {
+            id: 11,
+            start_offset: 11,
+            end_offset: 12,
+            blocks: vec![
+                BlockId::new(100),
+                BlockId::new(101),
+                BlockId::new(104),
+                BlockId::new(105),
+            ],
+            handlers: Vec::new(),
+            parent: None,
+            children: vec![12],
+            normal_exit_blocks: Vec::new(),
+        };
+        let nested = crate::ir::exception::TryRegion {
+            id: 12,
+            start_offset: 12,
+            end_offset: 13,
+            blocks: shared.to_vec(),
+            handlers: Vec::new(),
+            parent: Some(11),
+            children: Vec::new(),
+            normal_exit_blocks: Vec::new(),
+        };
+        let analysis = ExceptionAnalysis {
+            regions: vec![
+                owner(3, BlockId::new(76)),
+                owner(4, BlockId::new(71)),
+                owner(6, BlockId::new(66)),
+                explicit_parent,
+                nested,
+            ],
+            ..ExceptionAnalysis::default()
+        };
+        let sources = analysis
+            .regions
+            .iter()
+            .map(|region| (region.id, region))
+            .collect::<BTreeMap<_, _>>();
+        let tree = RegionTree::new(Some(entry));
+        let representatives = BTreeMap::new();
+        let builder = ExceptionRegionTreeBuilder::new(
+            &analysis,
+            &cfg,
+            &facts,
+            &cfg,
+            &facts,
+            &representatives,
+            tree,
+        );
+
+        assert!(matches!(
+            builder.parent_of(sources[&12], &sources),
+            Ok(ExceptionParent::Try(11))
+        ));
+    }
+
+    #[test]
+    fn shared_handler_suffix_is_not_owned_by_region_id_tie_breaking() {
+        let entry = BlockId::new(0);
+        let suffix = BTreeSet::from([BlockId::new(10), BlockId::new(11)]);
+        let mut cfg = CFG::new("shared_handler_suffix_nesting");
+        for block in [entry, BlockId::new(1), BlockId::new(2)]
+            .into_iter()
+            .chain(suffix.iter().copied())
+        {
+            cfg.add_block(Block::new(block.raw()));
+        }
+        cfg.add_edge(entry, BlockId::new(1), EdgeKind::Normal);
+        cfg.add_edge(BlockId::new(1), BlockId::new(2), EdgeKind::Normal);
+        cfg.add_edge(BlockId::new(2), BlockId::new(10), EdgeKind::Normal);
+        cfg.add_edge(BlockId::new(10), BlockId::new(11), EdgeKind::Normal);
+        let facts = ControlFlowFacts::analyze(&cfg).expect("control-flow facts");
+        let mut tree = RegionTree::new(Some(entry));
+        tree.cover_method(&cfg).expect("method ownership");
+        let root = tree.root();
+        let fragment = tree
+            .add_child(root, RegionKind::Try, Some(BlockId::new(10)))
+            .expect("shared try fragment");
+        for block in &suffix {
+            tree.add_block(fragment, *block).expect("fragment block");
+        }
+
+        let analysis = ExceptionAnalysis::default();
+        let representatives = BTreeMap::new();
+        let mut builder = ExceptionRegionTreeBuilder::new(
+            &analysis,
+            &cfg,
+            &facts,
+            &cfg,
+            &facts,
+            &representatives,
+            tree,
+        );
+        let handler_kind = || {
+            RegionKind::Catch(CatchRegion {
+                exception_types: vec![crate::ir::ArgType::throwable()],
+                exception_value: None,
+                continuation: None,
+            })
+        };
+        let first = builder
+            .tree
+            .add_child(root, handler_kind(), Some(BlockId::new(1)))
+            .expect("first handler");
+        builder.handler_domains.insert(
+            first,
+            suffix.iter().copied().chain([BlockId::new(1)]).collect(),
+        );
+        builder
+            .nest_regions_in_handlers()
+            .expect("provisional nesting");
+        assert_eq!(builder.tree.region(fragment).unwrap().parent, Some(first));
+
+        let second = builder
+            .tree
+            .add_child(root, handler_kind(), Some(BlockId::new(2)))
+            .expect("second handler");
+        builder.handler_domains.insert(
+            second,
+            suffix.iter().copied().chain([BlockId::new(2)]).collect(),
+        );
+        builder
+            .nest_regions_in_handlers()
+            .expect("shared-suffix nesting");
+
+        assert_eq!(builder.tree.region(fragment).unwrap().parent, Some(root));
     }
 
     #[test]

--- a/dexdec/src/ir/region/exits.rs
+++ b/dexdec/src/ir/region/exits.rs
@@ -250,11 +250,10 @@ impl<'a> RegionExitAnalysis<'a> {
                     continue;
                 }
                 let target_region = self.tree.owner(target_block)?;
-                let destination_block = self
-                    .cleanup_representatives
-                    .get(&target_block)
-                    .copied()
-                    .unwrap_or(target_block);
+                let destination_block = Self::terminal_cleanup_representative(
+                    self.cleanup_representatives,
+                    target_block,
+                );
                 let destination_region = self.tree.owner(destination_block)?;
                 let kind = self.transfer_kind(source_region, destination_region)?;
                 let mut transfer = RegionTransfer {
@@ -477,6 +476,26 @@ impl<'a> RegionExitAnalysis<'a> {
         } else {
             RegionTransferKind::Leave
         })
+    }
+
+    fn terminal_cleanup_representative(
+        representatives: &BTreeMap<BlockId, BlockId>,
+        target: BlockId,
+    ) -> BlockId {
+        let mut current = target;
+        let mut visited = BTreeSet::new();
+        loop {
+            if !visited.insert(current) {
+                // Cleanup proofs are expected to point toward a completion.
+                // Preserve the physical target if malformed input ever
+                // introduces a cycle instead of choosing an arbitrary member.
+                return target;
+            }
+            let Some(next) = representatives.get(&current).copied() else {
+                return current;
+            };
+            current = next;
+        }
     }
 
     fn exit_kind(
@@ -926,6 +945,72 @@ mod tests {
         let facts = ControlFlowFacts::analyze(&cfg).unwrap();
 
         assert_eq!(facts.continuation(BlockId::new(1)), BlockId::new(2));
+    }
+
+    #[test]
+    fn follows_nested_cleanup_contractions_to_the_terminal_representative() {
+        let source = BlockId::new(0);
+        let first = BlockId::new(1);
+        let second = BlockId::new(2);
+        let terminal = BlockId::new(3);
+        let representatives = BTreeMap::from([(first, second), (second, terminal)]);
+
+        let lock = InsnArg::reg_ssa(0, 0, ArgType::object("java/lang/Object"));
+        let result = RegisterArg::new_ssa(1, 0, ArgType::INT);
+        let mut cfg = CFG::new("nested_cleanup_return");
+        let mut entry = Block::new(source.raw());
+        entry.push(InsnNode::goto(1));
+        cfg.add_block(entry);
+        let mut first_cleanup = Block::new(first.raw());
+        first_cleanup.push(InsnNode::monitor_exit(lock.clone()));
+        first_cleanup.push(InsnNode::goto(2));
+        cfg.add_block(first_cleanup);
+        let mut second_cleanup = Block::new(second.raw());
+        second_cleanup.push(InsnNode::monitor_exit(lock));
+        second_cleanup.push(InsnNode::goto(3));
+        cfg.add_block(second_cleanup);
+        let mut completion = Block::new(terminal.raw());
+        completion.push(InsnNode::const_val(result.clone(), 1, ArgType::INT));
+        let mut return_value = InsnNode::new(InsnType::Return, 1);
+        return_value.add_arg(InsnArg::Reg(result));
+        completion.push(return_value);
+        cfg.add_block(completion);
+        cfg.add_edge(source, first, EdgeKind::Normal);
+        cfg.add_edge(first, second, EdgeKind::Normal);
+        cfg.add_edge(second, terminal, EdgeKind::Normal);
+
+        let mut tree = RegionTree::new(Some(source));
+        tree.cover_method(&cfg).unwrap();
+        let control_flow = ControlFlowFacts::analyze(&cfg).unwrap();
+        let elisions = InstructionElisions::default();
+        let handlers = BTreeMap::new();
+        let facts = RegionExitAnalysis::new(
+            &cfg,
+            &tree,
+            &elisions,
+            &control_flow,
+            &representatives,
+            &handlers,
+        )
+        .analyze()
+        .unwrap();
+        let transfer = facts
+            .transfers
+            .iter()
+            .find(|transfer| transfer.source_block == source)
+            .expect("entry transfer");
+        assert_eq!(transfer.destination_block, terminal);
+        assert_eq!(transfer.exit_kind, RegionExitKind::Return);
+        assert!(facts.leaves.iter().any(|leave| {
+            leave.leave.source_block == Some(source)
+                && matches!(leave.leave.exit, RegionExit::Return(Some(_)))
+        }));
+
+        let cyclic = BTreeMap::from([(first, second), (second, first)]);
+        assert_eq!(
+            RegionExitAnalysis::terminal_cleanup_representative(&cyclic, first),
+            first
+        );
     }
 
     #[test]

--- a/dexdec/src/ir/region/exits.rs
+++ b/dexdec/src/ir/region/exits.rs
@@ -257,7 +257,7 @@ impl<'a> RegionExitAnalysis<'a> {
                     .unwrap_or(target_block);
                 let destination_region = self.tree.owner(destination_block)?;
                 let kind = self.transfer_kind(source_region, destination_region)?;
-                transfers.push(RegionTransfer {
+                let mut transfer = RegionTransfer {
                     source_block,
                     target_block,
                     edge_kind,
@@ -270,7 +270,11 @@ impl<'a> RegionExitAnalysis<'a> {
                         .transpose()?,
                     kind,
                     exit_kind: self.exit_kind(source_block, destination_block, source_region)?,
-                });
+                };
+                if self.forwarded_cleanup_throw(&transfer)?.is_some() {
+                    transfer.exit_kind = RegionExitKind::Throw;
+                }
+                transfers.push(transfer);
             }
         }
         Ok(transfers)
@@ -282,13 +286,19 @@ impl<'a> RegionExitAnalysis<'a> {
     ) -> Result<Vec<RegionLeave>, RegionInvariantError> {
         let mut leaves = Vec::new();
         for transfer in transfers {
+            let forwarded_cleanup = self.forwarded_cleanup_throw(transfer)?;
             if !transfer.requires_leave(self.cfg) {
                 continue;
             }
             let target = transfer.exit_destination(self.tree.root());
-            let exit = match transfer.exit_kind {
-                RegionExitKind::FallThrough => RegionExit::FallThrough(transfer.destination_block),
-                RegionExitKind::Return => self
+            let exit = match (forwarded_cleanup, transfer.exit_kind) {
+                (Some(exception), RegionExitKind::Throw) => {
+                    RegionExit::Throw(InsnArg::Reg(exception))
+                }
+                (None, RegionExitKind::FallThrough) => {
+                    RegionExit::FallThrough(transfer.destination_block)
+                }
+                (None, RegionExitKind::Return) => self
                     .terminal_continuation(
                         transfer.source_block,
                         self.control_flow.continuation(transfer.destination_block),
@@ -297,9 +307,9 @@ impl<'a> RegionExitAnalysis<'a> {
                         block: transfer.source_block,
                         kind: transfer.exit_kind,
                     })?,
-                RegionExitKind::Break => RegionExit::Break,
-                RegionExitKind::Continue => RegionExit::Continue,
-                kind => {
+                (None, RegionExitKind::Break) => RegionExit::Break,
+                (None, RegionExitKind::Continue) => RegionExit::Continue,
+                (_, kind) => {
                     return Err(RegionInvariantError::InvalidLeaveKind {
                         block: transfer.source_block,
                         kind,
@@ -389,6 +399,46 @@ impl<'a> RegionExitAnalysis<'a> {
             leaves.push(leave);
         }
         Ok(leaves)
+    }
+
+    /// A nested compiler cleanup can forward its caught exception directly
+    /// into an enclosing source-level finally body. Once that finally is
+    /// represented lexically, retaining the physical edge as a fallthrough
+    /// would execute the cleanup and then jump back to its entry. Model the
+    /// proven cleanup handler's logical completion as a rethrow instead.
+    fn forwarded_cleanup_throw(
+        &self,
+        transfer: &RegionTransfer,
+    ) -> Result<Option<RegisterArg>, RegionInvariantError> {
+        if transfer.kind != RegionTransferKind::Leave
+            || !matches!(
+                transfer.exit_kind,
+                RegionExitKind::FallThrough | RegionExitKind::Throw
+            )
+        {
+            return Ok(None);
+        }
+        let source = self
+            .tree
+            .region(transfer.source_region)
+            .ok_or(RegionInvariantError::UnknownRegion(transfer.source_region))?;
+        let RegionKind::Cleanup(cleanup) = &source.kind else {
+            return Ok(None);
+        };
+        let destination = self.tree.region(transfer.destination_region).ok_or(
+            RegionInvariantError::UnknownRegion(transfer.destination_region),
+        )?;
+        if !matches!(&destination.kind, RegionKind::Finally)
+            || destination.entry != Some(transfer.destination_block)
+        {
+            return Ok(None);
+        }
+        let target = transfer.exit_destination(self.tree.root());
+        let cleanups = self.cleanup_chain(transfer.source_region, target)?;
+        if !cleanups.contains(&transfer.destination_region) {
+            return Ok(None);
+        }
+        Ok(cleanup.exception_value.clone())
     }
 
     fn resolve(&self, leave: RegionLeave) -> Result<ResolvedRegionExit, RegionInvariantError> {
@@ -744,7 +794,76 @@ impl InstructionTransform for LocalValueSubstitution<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{ArgType, Block, InsnArg, InsnNode, RegisterArg};
+    use crate::ir::{ArgType, Block, CatchRegion, InsnArg, InsnNode, RegisterArg};
+
+    #[test]
+    fn cleanup_forwarding_to_enclosing_finally_is_a_rethrow() {
+        let source = BlockId::new(0);
+        let finally_entry = BlockId::new(1);
+        let exception = RegisterArg::new_ssa(0, 0, ArgType::throwable());
+
+        let mut cfg = CFG::new("forwarded_cleanup_throw");
+        let mut adapter = Block::new(source.raw());
+        adapter.push(InsnNode::goto(1));
+        cfg.add_block(adapter);
+        let mut cleanup_body = Block::new(finally_entry.raw());
+        cleanup_body.push(InsnNode::throw(InsnArg::Reg(exception.clone())));
+        cfg.add_block(cleanup_body);
+        cfg.add_edge(source, finally_entry, EdgeKind::Normal);
+
+        let mut tree = RegionTree::new(Some(source));
+        tree.cover_method(&cfg).unwrap();
+        let root = tree.root();
+        let outer = tree.add_child(root, RegionKind::Try, Some(source)).unwrap();
+        let inner = tree
+            .add_child(outer, RegionKind::Try, Some(source))
+            .unwrap();
+        let adapter_region = tree
+            .add_child(
+                inner,
+                RegionKind::Cleanup(CatchRegion {
+                    exception_types: vec![ArgType::throwable()],
+                    exception_value: Some(exception.clone()),
+                    continuation: None,
+                }),
+                Some(source),
+            )
+            .unwrap();
+        let finally_region = tree
+            .add_child(root, RegionKind::Finally, Some(finally_entry))
+            .unwrap();
+        for region in [outer, inner, adapter_region] {
+            tree.add_block(region, source).unwrap();
+        }
+        tree.add_block(finally_region, finally_entry).unwrap();
+
+        let handlers =
+            BTreeMap::from([(outer, vec![finally_region]), (inner, vec![adapter_region])]);
+        let control_flow = ControlFlowFacts::analyze(&cfg).unwrap();
+        let elisions = InstructionElisions::default();
+        let contractions = BTreeMap::new();
+        let leaves = RegionExitAnalysis::new(
+            &cfg,
+            &tree,
+            &elisions,
+            &control_flow,
+            &contractions,
+            &handlers,
+        )
+        .analyze()
+        .unwrap()
+        .leaves;
+
+        let forwarded = leaves
+            .iter()
+            .find(|leave| leave.leave.source_block == Some(source))
+            .expect("cleanup adapter leave");
+        assert!(matches!(
+            &forwarded.leave.exit,
+            RegionExit::Throw(InsnArg::Reg(value)) if value == &exception
+        ));
+        assert_eq!(forwarded.cleanup_regions, vec![finally_region]);
+    }
 
     #[test]
     fn resolves_a_synthetic_control_edge_to_its_logical_destination() {

--- a/dexdec/src/ir/region/exits.rs
+++ b/dexdec/src/ir/region/exits.rs
@@ -402,10 +402,11 @@ impl<'a> RegionExitAnalysis<'a> {
     }
 
     /// A nested compiler cleanup can forward its caught exception directly
-    /// into an enclosing source-level finally body. Once that finally is
-    /// represented lexically, retaining the physical edge as a fallthrough
-    /// would execute the cleanup and then jump back to its entry. Model the
-    /// proven cleanup handler's logical completion as a rethrow instead.
+    /// into an enclosing cleanup handler. Once that handler is represented
+    /// lexically as a finally or catch-all cleanup, its physical entry no
+    /// longer denotes an ordinary source continuation (and a finally could be
+    /// replayed). Model the proven cleanup handler's logical completion as a
+    /// rethrow instead.
     fn forwarded_cleanup_throw(
         &self,
         transfer: &RegionTransfer,
@@ -428,14 +429,29 @@ impl<'a> RegionExitAnalysis<'a> {
         let destination = self.tree.region(transfer.destination_region).ok_or(
             RegionInvariantError::UnknownRegion(transfer.destination_region),
         )?;
-        if !matches!(&destination.kind, RegionKind::Finally)
-            || destination.entry != Some(transfer.destination_block)
-        {
+        if destination.entry != Some(transfer.destination_block) {
             return Ok(None);
         }
         let target = transfer.exit_destination(self.tree.root());
-        let cleanups = self.cleanup_chain(transfer.source_region, target)?;
-        if !cleanups.contains(&transfer.destination_region) {
+        let forwarded_handler = if matches!(&destination.kind, RegionKind::Finally) {
+            self.cleanup_chain(transfer.source_region, target)?
+                .contains(&transfer.destination_region)
+        } else if matches!(&destination.kind, RegionKind::Cleanup(_)) {
+            let mut attached = false;
+            for (owner, handlers) in self.handlers {
+                if handlers.contains(&transfer.destination_region)
+                    && (*owner == transfer.source_region
+                        || self.tree.is_ancestor(*owner, transfer.source_region)?)
+                {
+                    attached = true;
+                    break;
+                }
+            }
+            attached
+        } else {
+            false
+        };
+        if !forwarded_handler {
             return Ok(None);
         }
         Ok(cleanup.exception_value.clone())
@@ -798,6 +814,29 @@ mod tests {
 
     #[test]
     fn cleanup_forwarding_to_enclosing_finally_is_a_rethrow() {
+        let (leaves, exception, handler) = cleanup_forwarding_leaves(true);
+        let forwarded = forwarded_cleanup_leave(&leaves);
+        assert!(matches!(
+            &forwarded.leave.exit,
+            RegionExit::Throw(InsnArg::Reg(value)) if value == &exception
+        ));
+        assert_eq!(forwarded.cleanup_regions, vec![handler]);
+    }
+
+    #[test]
+    fn cleanup_forwarding_to_enclosing_cleanup_is_a_rethrow() {
+        let (leaves, exception, _) = cleanup_forwarding_leaves(false);
+        let forwarded = forwarded_cleanup_leave(&leaves);
+        assert!(matches!(
+            &forwarded.leave.exit,
+            RegionExit::Throw(InsnArg::Reg(value)) if value == &exception
+        ));
+        assert!(forwarded.cleanup_regions.is_empty());
+    }
+
+    fn cleanup_forwarding_leaves(
+        source_level_finally: bool,
+    ) -> (Vec<ResolvedRegionExit>, RegisterArg, RegionId) {
         let source = BlockId::new(0);
         let finally_entry = BlockId::new(1);
         let exception = RegisterArg::new_ssa(0, 0, ArgType::throwable());
@@ -829,8 +868,17 @@ mod tests {
                 Some(source),
             )
             .unwrap();
+        let destination_kind = if source_level_finally {
+            RegionKind::Finally
+        } else {
+            RegionKind::Cleanup(CatchRegion {
+                exception_types: vec![ArgType::throwable()],
+                exception_value: Some(exception.clone()),
+                continuation: None,
+            })
+        };
         let finally_region = tree
-            .add_child(root, RegionKind::Finally, Some(finally_entry))
+            .add_child(root, destination_kind, Some(finally_entry))
             .unwrap();
         for region in [outer, inner, adapter_region] {
             tree.add_block(region, source).unwrap();
@@ -854,15 +902,14 @@ mod tests {
         .unwrap()
         .leaves;
 
-        let forwarded = leaves
+        (leaves, exception, finally_region)
+    }
+
+    fn forwarded_cleanup_leave(leaves: &[ResolvedRegionExit]) -> &ResolvedRegionExit {
+        leaves
             .iter()
-            .find(|leave| leave.leave.source_block == Some(source))
-            .expect("cleanup adapter leave");
-        assert!(matches!(
-            &forwarded.leave.exit,
-            RegionExit::Throw(InsnArg::Reg(value)) if value == &exception
-        ));
-        assert_eq!(forwarded.cleanup_regions, vec![finally_region]);
+            .find(|leave| leave.leave.source_block == Some(BlockId::new(0)))
+            .expect("cleanup adapter leave")
     }
 
     #[test]

--- a/dexdec/src/ir/region/exits.rs
+++ b/dexdec/src/ir/region/exits.rs
@@ -254,7 +254,9 @@ impl<'a> RegionExitAnalysis<'a> {
                     self.cleanup_representatives,
                     target_block,
                 );
-                let destination_region = self.tree.owner(destination_block)?;
+                let destination_region = self
+                    .tree
+                    .enter_destination(source_region, destination_block)?;
                 let kind = self.transfer_kind(source_region, destination_region)?;
                 let mut transfer = RegionTransfer {
                     source_block,
@@ -830,6 +832,67 @@ impl InstructionTransform for LocalValueSubstitution<'_> {
 mod tests {
     use super::*;
     use crate::ir::{ArgType, Block, CatchRegion, InsnArg, InsnNode, RegisterArg};
+
+    #[test]
+    fn enters_loop_when_header_is_shared_with_nested_try() {
+        // Parent → loop-header/try-entry must Enter the loop, not the nested try.
+        // Otherwise continue leaves inside the loop body target an inactive control.
+        let header = BlockId::new(1);
+        let body = BlockId::new(2);
+        let mut cfg = CFG::new("shared_loop_try_entry");
+        for id in 0..=2 {
+            cfg.add_block(Block::new(id));
+        }
+        cfg.add_edge(BlockId::new(0), header, EdgeKind::Normal);
+        cfg.add_edge(header, body, EdgeKind::Normal);
+        cfg.add_edge(body, header, EdgeKind::Normal);
+
+        let mut tree = RegionTree::new(Some(BlockId::new(0)));
+        tree.cover_method(&cfg).unwrap();
+        let root = tree.root();
+        let loop_region = tree
+            .add_child(
+                root,
+                RegionKind::Loop(crate::ir::LoopRegion {
+                    follow: None,
+                    latches: BTreeSet::from([body]),
+                }),
+                Some(header),
+            )
+            .unwrap();
+        tree.region_mut(loop_region).unwrap().blocks = BTreeSet::from([header, body]);
+        let nested_try = tree
+            .add_child(loop_region, RegionKind::Try, Some(header))
+            .unwrap();
+        tree.region_mut(nested_try).unwrap().blocks = BTreeSet::from([header]);
+
+        let control_flow = ControlFlowFacts::analyze(&cfg).unwrap();
+        let elisions = InstructionElisions::default();
+        let handlers = BTreeMap::new();
+        let facts = RegionExitAnalysis::new(
+            &cfg,
+            &tree,
+            &elisions,
+            &control_flow,
+            &BTreeMap::new(),
+            &handlers,
+        )
+        .analyze()
+        .unwrap();
+        let enter = facts
+            .transfers
+            .iter()
+            .find(|transfer| {
+                transfer.source_block == BlockId::new(0)
+                    && transfer.destination_block == header
+                    && transfer.kind == RegionTransferKind::Enter
+            })
+            .expect("enter transfer to shared header");
+        assert_eq!(
+            enter.destination_region, loop_region,
+            "shared loop/try header must enter the loop control region"
+        );
+    }
 
     #[test]
     fn cleanup_forwarding_to_enclosing_finally_is_a_rethrow() {

--- a/dexdec/src/ir/region/synchronization.rs
+++ b/dexdec/src/ir/region/synchronization.rs
@@ -396,6 +396,12 @@ impl<'a> SynchronizationAnalysis<'a> {
                         });
                     }
                     _ if InstructionEffects::is_ssa_bookkeeping(instruction) => {}
+                    // DEX compilers may materialize exception-edge values in
+                    // the synthetic release adapter before monitor-exit. Such
+                    // definitions have no observable effect of their own and
+                    // survive through SSA edge-value recovery after the
+                    // adapter is contracted.
+                    _ if InstructionEffects::of_tree(instruction).is_pure() => {}
                     _ => {
                         return Err(ReleaseProofError::UnexpectedInstruction {
                             block,
@@ -1004,5 +1010,91 @@ mod tests {
             analysis.identity(&first_value),
             analysis.identity(&other_value)
         );
+    }
+
+    #[test]
+    fn release_handler_allows_only_pure_exception_edge_definitions() {
+        let method_entry = BlockId::new(0);
+        let release_entry = BlockId::new(1);
+        let rethrow = BlockId::new(2);
+        let caught = RegisterArg::new_ssa(0, 0, ArgType::throwable());
+        let lock = RegisterArg::new_ssa(1, 0, ArgType::object("java/lang/Object"));
+        let edge_value = RegisterArg::new_ssa(2, 0, ArgType::LONG);
+
+        let mut entry = Block::new(method_entry.raw());
+        entry.push(InsnNode::const_val(
+            lock.clone(),
+            0,
+            ArgType::object("java/lang/Object"),
+        ));
+        entry.push(InsnNode::return_void());
+        let mut release = Block::new(release_entry.raw());
+        release.push(InsnNode::move_exception(caught.clone()));
+        release.push(InsnNode::const_val(edge_value, 0, ArgType::LONG));
+        release.push(InsnNode::monitor_exit(InsnArg::Reg(lock)));
+        let mut throw = Block::new(rethrow.raw());
+        throw.push(InsnNode::throw(InsnArg::Reg(caught.clone())));
+
+        let handler = CatchHandler {
+            id: 0,
+            catch_type: None,
+            handler_offset: 0,
+            entry_blocks: BTreeSet::from([release_entry]),
+            handler_block: release_entry,
+            semantic_entry: release_entry,
+            canonical_entry: release_entry,
+            adapter_blocks: BTreeSet::new(),
+            blocks: vec![release_entry, rethrow],
+            semantic_blocks: vec![release_entry, rethrow],
+            lexical_blocks: vec![release_entry, rethrow],
+            continuation: None,
+            exception_value: Some(caught.clone()),
+            canonical_exception_value: Some(caught),
+            rethrow_blocks: BTreeSet::from([rethrow]),
+            kind: crate::ir::HandlerKind::Cleanup,
+        };
+        let region = TryRegion {
+            id: 0,
+            start_offset: 0,
+            end_offset: 1,
+            blocks: vec![method_entry],
+            handlers: vec![handler],
+            parent: None,
+            children: Vec::new(),
+            normal_exit_blocks: Vec::new(),
+        };
+        let mut cfg = CFG::new("pure_release_adapter_definition");
+        cfg.entry = method_entry;
+        cfg.add_block(entry);
+        cfg.add_block(release);
+        cfg.add_block(throw);
+        cfg.add_edge(method_entry, release_entry, crate::ir::EdgeKind::Exception);
+        cfg.add_edge(release_entry, rethrow, crate::ir::EdgeKind::Normal);
+        cfg.identify_instructions();
+
+        let values = SsaValueGraph::build(&cfg).unwrap();
+        let dominators = DominatorTree::compute(&cfg).unwrap();
+        let regions = [region];
+        let analysis = SynchronizationAnalysis::new(&cfg, &values, &dominators, &regions);
+
+        assert!(analysis.prove_release(&regions[0].handlers[0]).is_ok());
+
+        drop(analysis);
+        cfg.block_mut(release_entry)
+            .unwrap()
+            .insns
+            .insert(2, invocation("Lexample/Observable;->record()V"));
+        cfg.identify_instructions();
+        let values = SsaValueGraph::build(&cfg).unwrap();
+        let dominators = DominatorTree::compute(&cfg).unwrap();
+        let analysis = SynchronizationAnalysis::new(&cfg, &values, &dominators, &regions);
+
+        assert!(matches!(
+            analysis.prove_release(&regions[0].handlers[0]),
+            Err(ReleaseProofError::UnexpectedInstruction {
+                instruction: InsnType::Invoke,
+                ..
+            })
+        ));
     }
 }

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -743,6 +743,39 @@ impl RegionTree {
             .ok_or(RegionInvariantError::MissingOwner(block))
     }
 
+    /// Region entered when control transfers from `source` to `block`.
+    ///
+    /// Prefer the outermost loop/switch under `source` that uses `block` as its
+    /// entry. Nested tries frequently share a loop header; entering the try
+    /// would skip the loop and leave later continue/break transfers inactive.
+    pub(super) fn enter_destination(
+        &self,
+        source: RegionId,
+        block: BlockId,
+    ) -> Result<RegionId, RegionInvariantError> {
+        let innermost = self.owner(block)?;
+        if source != innermost && !self.is_ancestor(source, innermost)? {
+            return Ok(innermost);
+        }
+        let mut preferred = innermost;
+        let mut current = Some(innermost);
+        while let Some(region_id) = current {
+            if region_id == source {
+                break;
+            }
+            let region = self
+                .region(region_id)
+                .ok_or(RegionInvariantError::UnknownRegion(region_id))?;
+            if matches!(&region.kind, RegionKind::Loop(_) | RegionKind::Switch(_))
+                && region.entry == Some(block)
+            {
+                preferred = region_id;
+            }
+            current = region.parent;
+        }
+        Ok(preferred)
+    }
+
     pub(super) fn verify(&self, cfg: &CFG) -> Result<(), RegionInvariantError> {
         let root = self
             .region(self.root)

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -1704,10 +1704,21 @@ impl SynchronizationPlacement {
         &self,
         tree: &mut RegionTree,
     ) -> Result<(), RegionInvariantError> {
+        let owner_ancestors = tree
+            .parent_chain(self.owner)?
+            .into_iter()
+            .skip(1)
+            .collect::<BTreeSet<_>>();
         let contained = tree
             .regions
             .values()
             .filter(|region| region.id != tree.root && region.id != self.owner)
+            // An enclosing try can cover exactly the synchronized body while
+            // providing source catches outside the monitor. It contains the
+            // same blocks, but moving it below its own synchronized child
+            // creates a parent cycle and inverts the release-before-catch
+            // semantics.
+            .filter(|region| !owner_ancestors.contains(&region.id))
             .filter(|region| !region.blocks.is_empty() && region.blocks.is_subset(&self.blocks))
             .map(|region| region.id)
             .collect::<BTreeSet<_>>();
@@ -1813,6 +1824,46 @@ mod tests {
             .unwrap();
         tree.region_mut(id).unwrap().blocks = blocks(body);
         id
+    }
+
+    #[test]
+    fn synchronization_reparenting_preserves_coincident_try_ancestor() {
+        let mut tree = RegionTree::new(Some(BlockId::new(0)));
+        let root = tree.root();
+        let outer_try = add_region(&mut tree, root, RegionKind::Try, 1, [1, 2]);
+        let owner = add_region(&mut tree, outer_try, RegionKind::Try, 1, [1, 2]);
+        let contained = add_region(
+            &mut tree,
+            outer_try,
+            RegionKind::Loop(LoopRegion {
+                follow: None,
+                latches: blocks([2]),
+            }),
+            2,
+            [2],
+        );
+        let placement = SynchronizationPlacement {
+            owner,
+            enter: BlockId::new(0),
+            lock: InsnArg::Reg(RegisterArg::new(
+                0,
+                ArgType::object("java/lang/Object"),
+            )),
+            entry: BlockId::new(1),
+            blocks: blocks([1, 2]),
+            release_handlers: BTreeSet::new(),
+            user_handlers: BTreeSet::new(),
+            release_segments: BTreeSet::new(),
+            duplicate_handlers: Vec::new(),
+            method: false,
+        };
+
+        placement.reparent_contained_regions(&mut tree).unwrap();
+
+        assert_eq!(tree.region(outer_try).unwrap().parent, Some(root));
+        assert_eq!(tree.region(owner).unwrap().parent, Some(outer_try));
+        assert_eq!(tree.region(contained).unwrap().parent, Some(owner));
+        assert_eq!(tree.parent_chain(owner).unwrap(), vec![owner, outer_try, root]);
     }
 
     #[test]

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -949,10 +949,23 @@ impl SynchronizationPlacement {
                 !release_handlers.contains(handler) && !nested_release_handlers.contains(handler)
             })
             .collect::<BTreeSet<_>>();
-        let mut blocks = blocks
-            .difference(&own_release_blocks)
-            .copied()
-            .collect::<BTreeSet<_>>();
+        // A declared-synchronized method is one source-level lexical scope.
+        // Runtime monitor analysis stops at each synthetic monitor-exit, so it
+        // omits return/throw tails split after the exit. Those tails still
+        // belong to the method body and can otherwise cross a user handler at
+        // the same region depth. Keep only the synthetic enter and this
+        // monitor's release handler outside the recovered source scope.
+        let mut blocks = if method {
+            cfg.block_ids()
+                .into_iter()
+                .filter(|block| *block != enter && !own_release_blocks.contains(block))
+                .collect::<BTreeSet<_>>()
+        } else {
+            blocks
+                .difference(&own_release_blocks)
+                .copied()
+                .collect::<BTreeSet<_>>()
+        };
         blocks.extend(user_handlers.iter().flat_map(|handler| {
             tree.region(*handler)
                 .into_iter()
@@ -1934,6 +1947,58 @@ mod tests {
             Some(RegionKind::Synchronized(_))
         ));
         assert_eq!(tree.region(synchronization).unwrap().blocks, scope);
+    }
+
+    #[test]
+    fn declared_synchronization_owns_split_return_tails() {
+        let mut cfg = CFG::new("declared_synchronized_return_tails");
+        for id in 0..=7 {
+            cfg.add_block(Block::new(id));
+        }
+
+        let mut tree = RegionTree::new(Some(BlockId::new(0)));
+        tree.cover_method(&cfg).unwrap();
+        let root = tree.root();
+        let release = add_region(
+            &mut tree,
+            root,
+            RegionKind::Cleanup(CatchRegion {
+                exception_types: vec![ArgType::throwable()],
+                exception_value: None,
+                continuation: None,
+            }),
+            4,
+            [4, 5],
+        );
+        let user_handler = add_region(
+            &mut tree,
+            root,
+            RegionKind::Catch(CatchRegion {
+                exception_types: vec![ArgType::throwable()],
+                exception_value: None,
+                continuation: None,
+            }),
+            6,
+            [6, 7],
+        );
+        let lock = InsnArg::Reg(RegisterArg::new(0, ArgType::object("java/lang/Object")));
+
+        let placement = SynchronizationPlacement::analyze(
+            &tree,
+            &cfg,
+            root,
+            &[release, user_handler],
+            lock,
+            BlockId::new(0),
+            BlockId::new(1),
+            &blocks([1, 2, 4, 6]),
+            &blocks([4]),
+            &BTreeSet::new(),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(placement.blocks, blocks([1, 2, 3, 6, 7]));
     }
 
     #[test]

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -1267,7 +1267,7 @@ impl SynchronizationPlacement {
         // non-throwing closure can still pull those tails into an enclosing
         // try, which then only partially overlaps the recovered synchronized
         // body. Drop them before looking for a lexical cut.
-        Self::strip_external_handler_continuations(tree, &self.blocks)?;
+        Self::strip_external_handler_continuations(tree, cfg, &self.blocks)?;
         let mut candidates = tree
             .regions
             .values()
@@ -1397,8 +1397,10 @@ impl SynchronizationPlacement {
 
     fn strip_external_handler_continuations(
         tree: &mut RegionTree,
+        cfg: &CFG,
         sync_blocks: &BTreeSet<BlockId>,
     ) -> Result<(), RegionInvariantError> {
+        let predecessors = cfg.normal_predecessor_snapshot();
         let tries = tree
             .regions
             .values()
@@ -1435,10 +1437,34 @@ impl SynchronizationPlacement {
             if external.is_empty() {
                 continue;
             }
-            tree.region_mut(try_region)
-                .ok_or(RegionInvariantError::UnknownRegion(try_region))?
-                .blocks
-                .retain(|block| !external.contains(block));
+            let region = tree
+                .region_mut(try_region)
+                .ok_or(RegionInvariantError::UnknownRegion(try_region))?;
+            region.blocks.retain(|block| !external.contains(block));
+            // Catch continuations that restart a surrounding loop may also be
+            // the try's lexical entry (via entry_connectors). Dropping them
+            // without repairing entry leaves `entry` outside `blocks`.
+            if let Some(entry) = region.entry {
+                if !region.blocks.contains(&entry) {
+                    let remaining = region.blocks.clone();
+                    region.entry = remaining
+                        .iter()
+                        .copied()
+                        .filter(|block| {
+                            *block == cfg.entry
+                                || predecessors
+                                    .get(block)
+                                    .into_iter()
+                                    .flatten()
+                                    .any(|predecessor| !remaining.contains(predecessor))
+                        })
+                        .min_by_key(|block| {
+                            cfg.block(*block)
+                                .map(|block| (block.offset, block.id.raw()))
+                                .unwrap_or((u32::MAX, block.raw()))
+                        });
+                }
+            }
         }
         Ok(())
     }
@@ -1971,10 +1997,7 @@ mod tests {
         let placement = SynchronizationPlacement {
             owner,
             enter: BlockId::new(0),
-            lock: InsnArg::Reg(RegisterArg::new(
-                0,
-                ArgType::object("java/lang/Object"),
-            )),
+            lock: InsnArg::Reg(RegisterArg::new(0, ArgType::object("java/lang/Object"))),
             entry: BlockId::new(1),
             blocks: blocks([1, 2]),
             release_handlers: BTreeSet::new(),
@@ -1989,7 +2012,10 @@ mod tests {
         assert_eq!(tree.region(outer_try).unwrap().parent, Some(root));
         assert_eq!(tree.region(owner).unwrap().parent, Some(outer_try));
         assert_eq!(tree.region(contained).unwrap().parent, Some(owner));
-        assert_eq!(tree.parent_chain(owner).unwrap(), vec![owner, outer_try, root]);
+        assert_eq!(
+            tree.parent_chain(owner).unwrap(),
+            vec![owner, outer_try, root]
+        );
     }
 
     #[test]
@@ -2149,7 +2175,11 @@ mod tests {
             Some(RegionKind::Synchronized(_))
         ));
         assert_eq!(tree.region(nested).unwrap().blocks, blocks([2, 3]));
-        assert!(!tree.region(nested).unwrap().blocks.contains(&BlockId::new(4)));
+        assert!(!tree
+            .region(nested)
+            .unwrap()
+            .blocks
+            .contains(&BlockId::new(4)));
     }
 
     #[test]

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -934,14 +934,7 @@ impl SynchronizationPlacement {
         // source body. Nested release handlers remain lexically enclosed by
         // every outer synchronization, even though their inner owner elides
         // them during semantic lowering.
-        let own_release_blocks = release_handlers
-            .iter()
-            .flat_map(|handler| {
-                tree.region(*handler)
-                    .into_iter()
-                    .flat_map(|region| region.blocks.iter().copied())
-            })
-            .collect::<BTreeSet<_>>();
+        let own_release_blocks = Self::region_subtree_blocks(tree, &release_handlers)?;
         let user_handlers = handlers
             .iter()
             .copied()
@@ -1002,7 +995,7 @@ impl SynchronizationPlacement {
     }
 
     fn apply(
-        self,
+        mut self,
         tree: &mut RegionTree,
         cfg: &CFG,
         region_handlers: &BTreeMap<RegionId, Vec<RegionId>>,
@@ -1014,6 +1007,12 @@ impl SynchronizationPlacement {
         let handler_splits = self.preserve_user_handlers(tree, cfg, region_handlers)?;
         self.partition_handler_regions(tree, cfg)?;
         let splits = self.partition_try_regions(tree, cfg)?;
+        // Closing over a loop or switch can temporarily pull a synthetic
+        // release subtree back into the recovered source body. Once handler
+        // boundaries have been partitioned, exclude the final release tree so
+        // monitor-exit retries remain represented by `synchronized` itself.
+        let release_blocks = Self::region_subtree_blocks(tree, &self.release_handlers)?;
+        self.blocks.retain(|block| !release_blocks.contains(block));
         self.place_owner(tree)?;
         self.reparent_contained_regions(tree)?;
         self.mark_release_handlers(tree)?;
@@ -1035,6 +1034,26 @@ impl SynchronizationPlacement {
             splits,
             handler_splits,
         })
+    }
+
+    fn region_subtree_blocks(
+        tree: &RegionTree,
+        roots: &BTreeSet<RegionId>,
+    ) -> Result<BTreeSet<BlockId>, RegionInvariantError> {
+        let mut blocks = BTreeSet::new();
+        let mut pending = roots.iter().copied().collect::<Vec<_>>();
+        let mut visited = BTreeSet::new();
+        while let Some(region_id) = pending.pop() {
+            if !visited.insert(region_id) {
+                continue;
+            }
+            let region = tree
+                .region(region_id)
+                .ok_or(RegionInvariantError::UnknownRegion(region_id))?;
+            blocks.extend(region.blocks.iter().copied());
+            pending.extend(region.children.iter().copied());
+        }
+        Ok(blocks)
     }
 
     fn preserve_user_handlers(
@@ -1999,6 +2018,60 @@ mod tests {
         .unwrap();
 
         assert_eq!(placement.blocks, blocks([1, 2, 3, 6, 7]));
+    }
+
+    #[test]
+    fn synchronization_excludes_release_blocks_reintroduced_by_control_closure() {
+        let mut cfg = CFG::new("synchronized_release_retry_loop");
+        for id in 0..=4 {
+            cfg.add_block(Block::new(id));
+        }
+
+        let mut tree = RegionTree::new(Some(BlockId::new(0)));
+        tree.cover_method(&cfg).unwrap();
+        let root = tree.root();
+        let owner = add_region(&mut tree, root, RegionKind::Try, 1, [1, 2, 3, 4]);
+        let release = add_region(
+            &mut tree,
+            root,
+            RegionKind::Cleanup(CatchRegion {
+                exception_types: vec![ArgType::throwable()],
+                exception_value: None,
+                continuation: None,
+            }),
+            4,
+            [4],
+        );
+        let retry_loop = add_region(
+            &mut tree,
+            root,
+            RegionKind::Loop(LoopRegion {
+                follow: None,
+                latches: blocks([4]),
+            }),
+            3,
+            [3, 4],
+        );
+        let lock = InsnArg::Reg(RegisterArg::new(0, ArgType::object("java/lang/Object")));
+
+        tree.synchronize(
+            &cfg,
+            &BTreeMap::new(),
+            owner,
+            &[release],
+            lock,
+            BlockId::new(0),
+            BlockId::new(1),
+            &blocks([1, 2, 3, 4]),
+            &blocks([4]),
+            &BTreeSet::from([retry_loop]),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(tree.region(owner).unwrap().blocks, blocks([1, 2, 3]));
+        assert_eq!(tree.region(release).unwrap().blocks, blocks([4]));
+        tree.verify(&cfg).unwrap();
     }
 
     #[test]

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -1262,7 +1262,15 @@ impl SynchronizationPlacement {
                 .region(candidate)
                 .cloned()
                 .ok_or(RegionInvariantError::UnknownRegion(candidate))?;
-            if region.blocks.contains(&self.enter) || region.blocks.contains(&self.entry) {
+            if region.blocks.contains(&self.enter)
+                || region.blocks.contains(&self.entry)
+                || tree.is_ancestor(candidate, self.owner)?
+            {
+                // An enclosing try of the synchronization owner may omit the
+                // post-monitor-enter split block (especially for declared-
+                // synchronized methods whose enter stays on the method entry).
+                // Close that try over the recovered synchronized scope instead
+                // of demanding an impossible lexical cut.
                 tree.region_mut(candidate)
                     .ok_or(RegionInvariantError::UnknownRegion(candidate))?
                     .blocks
@@ -2156,6 +2164,65 @@ mod tests {
             Some(RegionKind::Synchronized(_))
         ));
         assert_eq!(tree.region(synchronization).unwrap().blocks, scope);
+    }
+
+    #[test]
+    fn synchronization_closes_ancestor_try_missing_split_entry() {
+        let mut cfg = CFG::new("declared_synchronized_split_entry");
+        for id in 0..=5 {
+            cfg.add_block(Block::new(id));
+        }
+        for (source, target) in [(0, 1), (1, 2), (2, 3)] {
+            cfg.add_edge(BlockId::new(source), BlockId::new(target), EdgeKind::Normal);
+        }
+        for source in 1..=2 {
+            cfg.add_edge(BlockId::new(source), BlockId::new(4), EdgeKind::Exception);
+        }
+        cfg.add_edge(BlockId::new(4), BlockId::new(5), EdgeKind::Normal);
+
+        let mut tree = RegionTree::new(Some(BlockId::new(0)));
+        tree.cover_method(&cfg).unwrap();
+        let root = tree.root();
+        // Outer try owns the original body but not the post-enter split block.
+        let outer = add_region(&mut tree, root, RegionKind::Try, 2, [2, 3, 4]);
+        let owner = add_region(&mut tree, outer, RegionKind::Try, 2, [2, 3]);
+        let release = add_region(
+            &mut tree,
+            root,
+            RegionKind::Cleanup(CatchRegion {
+                exception_types: vec![ArgType::throwable()],
+                exception_value: None,
+                continuation: None,
+            }),
+            4,
+            [4, 5],
+        );
+        let lock = InsnArg::Reg(RegisterArg::new(0, ArgType::object("java/lang/Object")));
+
+        tree.synchronize(
+            &cfg,
+            &BTreeMap::from([(owner, vec![release])]),
+            owner,
+            &[release],
+            lock,
+            BlockId::new(0),
+            BlockId::new(1),
+            &blocks([1, 2, 3]),
+            &blocks([4]),
+            &BTreeSet::new(),
+            false,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            tree.region(owner).map(|region| &region.kind),
+            Some(RegionKind::Synchronized(_))
+        ));
+        assert!(tree
+            .region(outer)
+            .unwrap()
+            .blocks
+            .is_superset(&blocks([1, 2, 3])));
     }
 
     #[test]

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -1230,6 +1230,11 @@ impl SynchronizationPlacement {
         tree: &mut RegionTree,
         cfg: &CFG,
     ) -> Result<Vec<(RegionId, RegionId)>, RegionInvariantError> {
+        // Catch/cleanup continuations may sit after monitor-exit. Private
+        // non-throwing closure can still pull those tails into an enclosing
+        // try, which then only partially overlaps the recovered synchronized
+        // body. Drop them before looking for a lexical cut.
+        Self::strip_external_handler_continuations(tree, &self.blocks)?;
         let mut candidates = tree
             .regions
             .values()
@@ -1337,6 +1342,54 @@ impl SynchronizationPlacement {
         Ok(splits)
     }
 
+    fn strip_external_handler_continuations(
+        tree: &mut RegionTree,
+        sync_blocks: &BTreeSet<BlockId>,
+    ) -> Result<(), RegionInvariantError> {
+        let tries = tree
+            .regions
+            .values()
+            .filter(|region| matches!(region.kind, RegionKind::Try))
+            .map(|region| region.id)
+            .collect::<Vec<_>>();
+        for try_region in tries {
+            let children = tree
+                .region(try_region)
+                .ok_or(RegionInvariantError::UnknownRegion(try_region))?
+                .children
+                .clone();
+            let mut pending = children;
+            let mut visited = BTreeSet::new();
+            let mut external = BTreeSet::new();
+            while let Some(child) = pending.pop() {
+                if !visited.insert(child) {
+                    continue;
+                }
+                let Some(region) = tree.region(child) else {
+                    continue;
+                };
+                pending.extend(region.children.iter().copied());
+                let continuation = match &region.kind {
+                    RegionKind::Catch(catch) | RegionKind::Cleanup(catch) => catch.continuation,
+                    _ => None,
+                };
+                if let Some(block) = continuation {
+                    if !sync_blocks.contains(&block) {
+                        external.insert(block);
+                    }
+                }
+            }
+            if external.is_empty() {
+                continue;
+            }
+            tree.region_mut(try_region)
+                .ok_or(RegionInvariantError::UnknownRegion(try_region))?
+                .blocks
+                .retain(|block| !external.contains(block));
+        }
+        Ok(())
+    }
+
     fn remove_release_segments(
         &self,
         tree: &mut RegionTree,
@@ -1400,11 +1453,6 @@ impl SynchronizationPlacement {
             let Some(entry) = region.entry else {
                 continue;
             };
-            let boundary =
-                LexicalBoundaryAnalysis::new(cfg).partition(entry, &region.blocks, blocks);
-            let Some(boundary) = boundary else {
-                continue;
-            };
             let parent = region
                 .parent
                 .ok_or(RegionInvariantError::MissingRegionParent {
@@ -1412,6 +1460,12 @@ impl SynchronizationPlacement {
                     parent: tree.root,
                 })?;
             let children = region.children.clone();
+            let region_blocks = region.blocks.clone();
+            let boundary =
+                LexicalBoundaryAnalysis::new(cfg).partition(entry, &region_blocks, blocks);
+            let Some(boundary) = boundary else {
+                continue;
+            };
             let mut promote = Vec::new();
             let mut crossing = None;
             for child in children {
@@ -1443,6 +1497,10 @@ impl SynchronizationPlacement {
                 });
             }
 
+            let removed = region_blocks
+                .difference(&boundary.blocks)
+                .copied()
+                .collect::<BTreeSet<_>>();
             let kind = &mut tree
                 .region_mut(candidate)
                 .ok_or(RegionInvariantError::UnknownRegion(candidate))?
@@ -1458,6 +1516,21 @@ impl SynchronizationPlacement {
             tree.region_mut(candidate)
                 .ok_or(RegionInvariantError::UnknownRegion(candidate))?
                 .blocks = boundary.blocks;
+
+            // Keep enclosing tries laminar with the monitor: they must not
+            // retain the continuation that now sits outside the synchronized
+            // body.
+            let mut ancestor = Some(parent);
+            while let Some(region_id) = ancestor {
+                if Some(region_id) == owner || region_id == tree.root {
+                    break;
+                }
+                let current = tree
+                    .region_mut(region_id)
+                    .ok_or(RegionInvariantError::UnknownRegion(region_id))?;
+                ancestor = current.parent;
+                current.blocks.retain(|block| !removed.contains(block));
+            }
 
             for child in promote {
                 Self::unlink(tree, candidate, child)?;
@@ -1958,6 +2031,72 @@ mod tests {
         tree.canonicalize_nesting().unwrap();
 
         assert_eq!(tree.region(protected).unwrap().parent, Some(handler));
+    }
+
+    #[test]
+    fn synchronization_strips_nested_try_handler_continuations_outside_monitor() {
+        let mut cfg = CFG::new("synchronized_try_external_continuation");
+        for id in 0..=6 {
+            cfg.add_block(Block::new(id));
+        }
+        for (source, target) in [(0, 1), (1, 2), (2, 3), (3, 4)] {
+            cfg.add_edge(BlockId::new(source), BlockId::new(target), EdgeKind::Normal);
+        }
+        for source in 1..=3 {
+            cfg.add_edge(BlockId::new(source), BlockId::new(5), EdgeKind::Exception);
+        }
+        cfg.add_edge(BlockId::new(5), BlockId::new(6), EdgeKind::Normal);
+
+        let mut tree = RegionTree::new(Some(BlockId::new(0)));
+        tree.cover_method(&cfg).unwrap();
+        let root = tree.root();
+        let owner = add_region(&mut tree, root, RegionKind::Try, 1, [1, 2, 3]);
+        let nested = add_region(&mut tree, owner, RegionKind::Try, 2, [2, 3, 4]);
+        let catch = add_region(
+            &mut tree,
+            nested,
+            RegionKind::Catch(CatchRegion {
+                exception_types: vec![ArgType::object("java/lang/Exception")],
+                exception_value: None,
+                continuation: Some(BlockId::new(4)),
+            }),
+            3,
+            [3],
+        );
+        let release = add_region(
+            &mut tree,
+            root,
+            RegionKind::Cleanup(CatchRegion {
+                exception_types: vec![ArgType::throwable()],
+                exception_value: None,
+                continuation: None,
+            }),
+            5,
+            [5, 6],
+        );
+        let lock = InsnArg::Reg(RegisterArg::new(0, ArgType::object("java/lang/Object")));
+
+        tree.synchronize(
+            &cfg,
+            &BTreeMap::from([(owner, vec![catch, release])]),
+            owner,
+            &[catch, release],
+            lock,
+            BlockId::new(0),
+            BlockId::new(1),
+            &blocks([1, 2, 3]),
+            &blocks([5]),
+            &BTreeSet::new(),
+            false,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            tree.region(owner).map(|region| &region.kind),
+            Some(RegionKind::Synchronized(_))
+        ));
+        assert_eq!(tree.region(nested).unwrap().blocks, blocks([2, 3]));
+        assert!(!tree.region(nested).unwrap().blocks.contains(&BlockId::new(4)));
     }
 
     #[test]

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -1271,10 +1271,22 @@ impl SynchronizationPlacement {
                 // synchronized methods whose enter stays on the method entry).
                 // Close that try over the recovered synchronized scope instead
                 // of demanding an impossible lexical cut.
-                tree.region_mut(candidate)
-                    .ok_or(RegionInvariantError::UnknownRegion(candidate))?
-                    .blocks
-                    .extend(self.blocks.iter().copied());
+                //
+                // Also realign the try entry onto the synchronized body entry.
+                // After monitor-enter splitting the try often still points at a
+                // later body block (e.g. B1 while sync enters at B724). Leaving
+                // that stale entry creates a second synchronized port and emits
+                // an empty `synchronized` prefix before the real monitor body.
+                let closed = tree
+                    .region_mut(candidate)
+                    .ok_or(RegionInvariantError::UnknownRegion(candidate))?;
+                closed.blocks.extend(self.blocks.iter().copied());
+                if closed
+                    .entry
+                    .is_some_and(|entry| entry != self.entry && self.blocks.contains(&entry))
+                {
+                    closed.entry = Some(self.entry);
+                }
                 continue;
             }
             let entry = region
@@ -2223,6 +2235,11 @@ mod tests {
             .unwrap()
             .blocks
             .is_superset(&blocks([1, 2, 3])));
+        assert_eq!(
+            tree.region(outer).and_then(|region| region.entry),
+            Some(BlockId::new(1)),
+            "enclosing try must enter at the synchronized body entry after split"
+        );
     }
 
     #[test]

--- a/dexdec/src/ir/region/verify.rs
+++ b/dexdec/src/ir/region/verify.rs
@@ -116,9 +116,10 @@ impl<'a> RegionGraphVerifier<'a> {
                 actual: transfer.target_region,
             });
         }
-        let destination = self.graph.owner_of(transfer.destination_block).ok_or(
-            RegionInvariantError::MissingOwner(transfer.destination_block),
-        )?;
+        let destination = self
+            .graph
+            .tree
+            .enter_destination(transfer.source_region, transfer.destination_block)?;
         if destination != transfer.destination_region {
             return Err(RegionInvariantError::TransferTargetMismatch {
                 block: transfer.destination_block,

--- a/dexdec/src/ir/structure/flow_graph.rs
+++ b/dexdec/src/ir/structure/flow_graph.rs
@@ -1677,8 +1677,14 @@ impl SemanticFolder for TerminalContinuationBinding<'_> {
 ///
 /// Exclusive paths are moved into the fragment. Shared paths are duplicated,
 /// which is the standard tail-duplication step used to recover a single-entry,
-/// single-exit region. Only transfer-free, normally completing nodes qualify,
-/// and a hard path budget bounds code growth.
+/// single-exit region. Only transfer-free, normally completing adapter nodes
+/// qualify, and a hard path budget bounds code growth.
+///
+/// Nodes that already carry lexical labels are never absorbed. After a fragment
+/// collapses to a single open exit, [`FragmentNormalizer::normalize`] wraps its
+/// body in a label; treating that structured unit as an Exclusive adapter would
+/// inline whole try/catch regions into earlier fragments and cascade into
+/// exponential duplication on sequential open-flow methods.
 struct LinearContinuation {
     source: BlockId,
     target: BlockId,
@@ -1695,6 +1701,13 @@ enum ContinuationUse {
 
 impl LinearContinuation {
     const DUPLICATION_BUDGET: usize = 32;
+
+    fn is_absorbable_adapter(body: &SemanticNode) -> bool {
+        let completion = SemanticCompletion::analyze(body);
+        completion.can_complete_normally()
+            && completion.is_transfer_free()
+            && LexicalIdentities::collect(body).labels.is_empty()
+    }
 
     fn analyze(graph: &SemanticFlowGraph) -> Result<Option<Self>, StructureError> {
         let predecessors = graph.predecessors();
@@ -1732,8 +1745,7 @@ impl LinearContinuation {
                     let Some(continuation) = graph.nodes.get(&current) else {
                         break;
                     };
-                    let completion = SemanticCompletion::analyze(&continuation.body);
-                    if !completion.can_complete_normally() || !completion.is_transfer_free() {
+                    if !Self::is_absorbable_adapter(&continuation.body) {
                         break;
                     }
                     let FlowTransfer::Jump(next) = &continuation.transfer else {
@@ -1744,15 +1756,6 @@ impl LinearContinuation {
                     current = *next;
                 }
                 if !blocks.is_empty() && !blocks.contains(&current) {
-                    if use_kind == ContinuationUse::Shared
-                        && blocks.iter().any(|block| {
-                            graph.nodes.get(block).is_some_and(|node| {
-                                !LexicalIdentities::collect(&node.body).labels.is_empty()
-                            })
-                        })
-                    {
-                        continue;
-                    }
                     return Ok(Some(Self {
                         source: *source,
                         target,
@@ -3845,6 +3848,97 @@ mod tests {
         assert_eq!(branch.join, join);
         assert_eq!(branch.true_arm.nodes, BTreeSet::from([when_true]));
         assert_eq!(branch.false_arm.nodes, BTreeSet::from([when_false]));
+    }
+
+    #[test]
+    fn linear_continuation_does_not_absorb_labeled_successor_fragments() {
+        // Sequential open-flow fragments collapse to labeled Jump nodes. Exclusive
+        // LinearContinuation must not treat those structured units as adapters, or
+        // each earlier fragment inlines the next and duplication cascades.
+        let first = BlockId::new(0);
+        let second = BlockId::new(1);
+        let join = BlockId::new(2);
+        let region = RegionId::new(0);
+        let second_label = SemanticLabel::block(region, BlockId::new(10));
+        let jump = |target| {
+            SemanticNode::Leave(crate::ir::SemanticLeave {
+                site: None,
+                condition: None,
+                kind: SemanticLeaveKind::Jump(target),
+                edge: None,
+                origin: None,
+                source: region,
+                destination: region,
+                target: region,
+                cleanup: Vec::new(),
+            })
+        };
+        let labeled_second = SemanticNode::Label {
+            label: second_label,
+            body: Box::new(SemanticNode::sequence([
+                SemanticNode::BasicBlock(crate::ir::SemanticBlock {
+                    id: second,
+                    statements: Vec::new(),
+                }),
+                SemanticNode::Leave(crate::ir::SemanticLeave {
+                    site: None,
+                    condition: None,
+                    kind: SemanticLeaveKind::BreakLabel(second_label),
+                    edge: None,
+                    origin: None,
+                    source: region,
+                    destination: region,
+                    target: region,
+                    cleanup: Vec::new(),
+                }),
+            ])),
+        };
+        let mut graph = SemanticFlowGraph {
+            region,
+            entry: first,
+            nodes: BTreeMap::from([
+                (
+                    first,
+                    FlowNode {
+                        body: SemanticNode::sequence([jump(second), jump(join)]),
+                        transfer: FlowTransfer::Fragment {
+                            normal: None,
+                            open: BTreeSet::from([second, join]),
+                        },
+                    },
+                ),
+                (
+                    second,
+                    FlowNode {
+                        body: labeled_second,
+                        transfer: FlowTransfer::Jump(join),
+                    },
+                ),
+                (
+                    join,
+                    FlowNode {
+                        body: SemanticNode::Empty,
+                        transfer: FlowTransfer::Stop,
+                    },
+                ),
+            ]),
+            next_id: 11,
+            continues: BTreeMap::new(),
+            exits: BTreeSet::new(),
+        };
+
+        FragmentNormalizer::apply(&mut graph).expect("fragment normalization");
+
+        assert!(
+            graph.nodes.contains_key(&second),
+            "labeled successor fragment must remain a separate graph node"
+        );
+        let first_weight = SemanticWeight::of(&graph.nodes[&first].body);
+        let second_weight = SemanticWeight::of(&graph.nodes[&second].body);
+        assert!(
+            first_weight < second_weight.saturating_mul(2).saturating_add(16),
+            "first fragment must not absorb the labeled successor body"
+        );
     }
 
     #[test]

--- a/dexdec/src/ir/structure/region_reducer.rs
+++ b/dexdec/src/ir/structure/region_reducer.rs
@@ -103,13 +103,23 @@ impl<'a> RegionReducer<'a> {
             pending.push((region, true));
             let children = RegionChildren::classify(self.cfg, self.regions, descriptor)?;
             let mut dependencies = children.ordinary;
-            dependencies.extend(
-                children
-                    .handlers
-                    .into_iter()
-                    .map(|handler| handlers.body_region(region, handler))
-                    .collect::<Result<Vec<_>, _>>()?,
-            );
+            for handler in children.handlers {
+                dependencies.push(handlers.body_region(region, handler)?);
+                if let Some((target, _)) = handlers.forwarded_catch_target(handler)? {
+                    // A split handler can be reduced before the shared catch
+                    // body it forwards into. Make that body an explicit
+                    // dependency unless it lexically contains this owner,
+                    // which would create a region cycle.
+                    if !self
+                        .regions
+                        .tree()
+                        .is_ancestor(target, region)
+                        .map_err(|_| StructureError::UnknownRegion(target))?
+                    {
+                        dependencies.push(target);
+                    }
+                }
+            }
             dependencies.sort();
             dependencies.dedup();
             pending.extend(dependencies.into_iter().rev().map(|child| (child, false)));

--- a/dexdec/src/ir/structure/region_reducer.rs
+++ b/dexdec/src/ir/structure/region_reducer.rs
@@ -466,13 +466,14 @@ impl<'a> RegionReducer<'a> {
             .collect();
         let local = &region_cfg.cfg;
         let has_open_flows = !region_cfg.open_flows.is_empty();
-        let is_switch_dispatch = matches!(kind, RegionKind::Switch(_))
-            && self
-                .regions
+        let is_switch_dispatch = Self::has_direct_switch_dispatch(
+            kind,
+            self.regions
                 .tree()
                 .region(region_id)
-                .and_then(|region| region.entry)
-                == Some(local.entry);
+                .and_then(|region| region.entry),
+            local,
+        );
         if is_switch_dispatch {
             return SwitchStructurer::new(local, &semantic, region_id, seeded)
                 .terminal_seeds(terminal_seeds)
@@ -483,6 +484,23 @@ impl<'a> RegionReducer<'a> {
             .terminal_seeds(terminal_seeds)
             .force_graph_reduction(has_open_flows)
             .structure()
+    }
+
+    fn has_direct_switch_dispatch(
+        kind: &RegionKind,
+        region_entry: Option<BlockId>,
+        local: &CFG,
+    ) -> bool {
+        // A child region can own the same physical entry as its switch parent.
+        // RegionCfgBuilder then preserves the entry as a contracted nop whose
+        // semantic body is supplied through `seeded`; only the original switch
+        // header satisfies SwitchStructurer's input contract.
+        matches!(kind, RegionKind::Switch(_))
+            && region_entry == Some(local.entry)
+            && local
+                .block(local.entry)
+                .and_then(|block| block.terminator())
+                .is_some_and(|terminator| terminator.insn_type == crate::ir::InsnType::Switch)
     }
 
     fn anchor_block(block: BlockId, continuation: SemanticNode) -> SemanticNode {
@@ -584,5 +602,37 @@ impl ReducedPort {
             body,
             continuations,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RegionReducer;
+    use crate::ir::{Block, BlockId, InsnNode, InsnType, RegionKind, SwitchRegion, CFG};
+
+    #[test]
+    fn contracted_switch_header_uses_general_structurer() {
+        let entry = BlockId::new(0);
+        let kind = RegionKind::Switch(SwitchRegion { follow: None });
+
+        let mut direct = CFG::new("direct_switch");
+        let mut header = Block::new(entry.raw());
+        header.push(InsnNode::new(InsnType::Switch, 0));
+        direct.add_block(header);
+        assert!(RegionReducer::has_direct_switch_dispatch(
+            &kind,
+            Some(entry),
+            &direct,
+        ));
+
+        let mut contracted = CFG::new("contracted_switch");
+        let mut header = Block::new(entry.raw());
+        header.push(InsnNode::nop());
+        contracted.add_block(header);
+        assert!(!RegionReducer::has_direct_switch_dispatch(
+            &kind,
+            Some(entry),
+            &contracted,
+        ));
     }
 }

--- a/dexdec/src/ir/structure/region_reducer/children.rs
+++ b/dexdec/src/ir/structure/region_reducer/children.rs
@@ -20,7 +20,7 @@ use super::{
 
 pub(super) struct RegionChildren {
     pub(super) ordinary: Vec<RegionId>,
-    pub(super) handlers: BTreeSet<RegionId>,
+    pub(super) handlers: Vec<RegionId>,
     pub(super) releases: BTreeSet<RegionId>,
 }
 
@@ -30,7 +30,11 @@ impl RegionChildren {
         graph: &RegionGraph,
         region: &StructuredRegion,
     ) -> Result<Self, StructureError> {
-        let mut handlers = BTreeSet::new();
+        // DEX handler order is semantic: a typed catch must remain before a
+        // later catch-all clause. Region ids describe construction order and
+        // cannot be used to sort catch clauses.
+        let mut handlers = Vec::new();
+        let mut seen_handlers = BTreeSet::new();
         for handler in graph.handlers_of(region.id).iter().copied() {
             if graph
                 .tree()
@@ -39,7 +43,9 @@ impl RegionChildren {
             {
                 continue;
             }
-            handlers.insert(handler);
+            if seen_handlers.insert(handler) {
+                handlers.push(handler);
+            }
         }
         let mut releases = graph
             .handlers_of(region.id)
@@ -50,7 +56,11 @@ impl RegionChildren {
         if let RegionKind::Synchronized(synchronized) = &region.kind {
             releases.extend(synchronized.release_handlers.iter().copied());
         }
-        handlers.extend(releases.iter().copied());
+        for release in releases.iter().copied() {
+            if seen_handlers.insert(release) {
+                handlers.push(release);
+            }
+        }
         let handler_reducer = HandlerReducer::new(graph);
         let handler_bodies = handlers
             .iter()

--- a/dexdec/src/ir/structure/region_reducer/children.rs
+++ b/dexdec/src/ir/structure/region_reducer/children.rs
@@ -43,6 +43,19 @@ impl RegionChildren {
             {
                 continue;
             }
+            let handler_kind = &graph
+                .tree()
+                .region(handler)
+                .ok_or(StructureError::UnknownRegion(handler))?
+                .kind;
+            // A catch clause with no exceptional ingress cannot affect this
+            // protected fragment. Finally and cleanup handlers may still be
+            // required on normal completion, so retain those unconditionally.
+            if matches!(handler_kind, RegionKind::Catch(_))
+                && !Self::reaches_handler(cfg, graph, region, handler)?
+            {
+                continue;
+            }
             if seen_handlers.insert(handler) {
                 handlers.push(handler);
             }
@@ -119,6 +132,46 @@ impl RegionChildren {
             handlers,
             releases,
         })
+    }
+
+    fn reaches_handler(
+        cfg: &CFG,
+        graph: &RegionGraph,
+        region: &StructuredRegion,
+        handler: RegionId,
+    ) -> Result<bool, StructureError> {
+        let handler_region = graph
+            .tree()
+            .region(handler)
+            .ok_or(StructureError::UnknownRegion(handler))?;
+        for source in &region.blocks {
+            for (target, kind) in cfg.successors_with_kind(*source) {
+                if !kind.is_exception() {
+                    continue;
+                }
+                for entry in
+                    std::iter::once(*target).chain(graph.handler_adapters().get(target).copied())
+                {
+                    if handler_region.entry.is_none()
+                        && handler_region.kind.continuation() == Some(entry)
+                    {
+                        return Ok(true);
+                    }
+                    let Some(owner) = graph.owner_of(entry) else {
+                        continue;
+                    };
+                    if owner == handler
+                        || graph
+                            .tree()
+                            .is_ancestor(handler, owner)
+                            .map_err(|_| StructureError::UnknownRegion(owner))?
+                    {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+        Ok(false)
     }
 
     fn externally_entered(
@@ -562,6 +615,122 @@ impl OpenFlowCompletion {
                 cleanup: Vec::new(),
             }),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::analysis::SsaValueGraph;
+    use crate::ir::exception::{CatchHandler, ExceptionAnalysis, TryRegion};
+    use crate::ir::{
+        ArgType, Block, HandlerKind, InsnNode, RegionGraphBuilder, RegionKind, RegisterArg,
+    };
+
+    #[test]
+    fn ignores_handler_dependency_without_exception_ingress() {
+        let (cfg, graph, owner) = graph_with_handler(false, HandlerKind::Catch);
+        let region = graph.tree().region(owner).expect("try region");
+        let children = RegionChildren::classify(&cfg, &graph, region).expect("children");
+
+        assert!(children.handlers.is_empty());
+    }
+
+    #[test]
+    fn retains_handler_dependency_with_exception_ingress() {
+        let (cfg, graph, owner) = graph_with_handler(true, HandlerKind::Catch);
+        let region = graph.tree().region(owner).expect("try region");
+        let children = RegionChildren::classify(&cfg, &graph, region).expect("children");
+
+        assert_eq!(children.handlers.len(), 1);
+    }
+
+    #[test]
+    fn retains_finally_dependency_without_exception_ingress() {
+        let (cfg, graph, owner) = graph_with_handler(false, HandlerKind::Finally);
+        let region = graph.tree().region(owner).expect("try region");
+        let children = RegionChildren::classify(&cfg, &graph, region).expect("children");
+
+        assert_eq!(children.handlers.len(), 1);
+    }
+
+    fn graph_with_handler(reachable: bool, kind: HandlerKind) -> (CFG, RegionGraph, RegionId) {
+        let entry = BlockId::new(0);
+        let protected = BlockId::new(1);
+        let completion = BlockId::new(2);
+        let handler = BlockId::new(3);
+        let mut cfg = CFG::new("handler_ingress");
+        let mut entry_block = Block::new(entry.raw());
+        entry_block.push(InsnNode::goto(protected.raw() as i32));
+        cfg.add_block(entry_block);
+        let mut protected_block = Block::new(protected.raw());
+        protected_block.push(InsnNode::goto(completion.raw() as i32));
+        cfg.add_block(protected_block);
+        let mut completion_block = Block::new(completion.raw());
+        completion_block.push(InsnNode::return_void());
+        cfg.add_block(completion_block);
+        let caught = RegisterArg::new_ssa(0, 0, ArgType::throwable());
+        let mut handler_block = Block::new(handler.raw());
+        handler_block.push(InsnNode::move_exception(caught.clone()));
+        handler_block.push(InsnNode::return_void());
+        cfg.add_block(handler_block);
+        cfg.add_edge(entry, protected, crate::ir::EdgeKind::Normal);
+        cfg.add_edge(protected, completion, crate::ir::EdgeKind::Normal);
+        if reachable {
+            cfg.add_edge(protected, handler, crate::ir::EdgeKind::Exception);
+        } else {
+            cfg.add_edge(entry, handler, crate::ir::EdgeKind::Exception);
+        }
+
+        let catch = CatchHandler {
+            id: handler.raw(),
+            catch_type: (kind == HandlerKind::Catch).then(ArgType::throwable),
+            handler_offset: handler.raw(),
+            entry_blocks: BTreeSet::from([handler]),
+            handler_block: handler,
+            semantic_entry: handler,
+            canonical_entry: handler,
+            adapter_blocks: BTreeSet::new(),
+            blocks: vec![handler],
+            semantic_blocks: vec![handler],
+            lexical_blocks: vec![handler],
+            continuation: None,
+            exception_value: Some(caught.clone()),
+            canonical_exception_value: Some(caught),
+            rethrow_blocks: BTreeSet::new(),
+            kind,
+        };
+        let analysis = ExceptionAnalysis {
+            regions: vec![TryRegion {
+                id: 7,
+                start_offset: protected.raw(),
+                end_offset: completion.raw(),
+                blocks: vec![protected],
+                handlers: vec![catch],
+                parent: None,
+                children: Vec::new(),
+                normal_exit_blocks: vec![protected],
+            }],
+            ..ExceptionAnalysis::default()
+        };
+        let values = SsaValueGraph::build(&cfg).expect("SSA values");
+        let graph = RegionGraphBuilder::new(&cfg, &analysis, &values)
+            .build()
+            .expect("region graph");
+        let owner = graph
+            .exception_regions()
+            .get(&7)
+            .into_iter()
+            .flatten()
+            .copied()
+            .find(|region| {
+                graph
+                    .tree()
+                    .region(*region)
+                    .is_some_and(|region| matches!(region.kind, RegionKind::Try))
+            })
+            .expect("source try region");
+        (cfg, graph, owner)
     }
 }
 

--- a/dexdec/src/ir/structure/region_reducer/envelopes.rs
+++ b/dexdec/src/ir/structure/region_reducer/envelopes.rs
@@ -30,11 +30,7 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
                 .collect::<Vec<_>>();
             if duplicates.is_empty() {
                 let root = self.merge_families(root)?;
-                return ExternalMonitorHandlerPlacement::apply(
-                    self.cfg,
-                    self.regions.tree(),
-                    root,
-                );
+                return self.finalize(root);
             }
 
             let mut changed = false;
@@ -56,13 +52,14 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
             }
             if !changed {
                 let root = self.merge_families(root)?;
-                return ExternalMonitorHandlerPlacement::apply(
-                    self.cfg,
-                    self.regions.tree(),
-                    root,
-                );
+                return self.finalize(root);
             }
         }
+    }
+
+    fn finalize(&self, root: SemanticNode) -> Result<SemanticNode, StructureError> {
+        let root = ExternalMonitorHandlerPlacement::apply(self.cfg, self.regions.tree(), root)?;
+        HandlerCleanupEnvelopePlacement::apply(self.regions, root)
     }
 
     fn merge_families(&self, mut root: SemanticNode) -> Result<SemanticNode, StructureError> {
@@ -1292,6 +1289,156 @@ impl SemanticFolder for ExternalMonitorHandlerPlacement<'_, '_> {
     }
 }
 
+/// A cleanup clause repeated around typed catch bodies is an outer lexical
+/// protection scope, not a sibling catch. Region reduction keeps the complete
+/// handler bodies here; nesting after envelope canonicalization prevents a
+/// shared coroutine handler tail from being moved outside the cleanup.
+struct HandlerCleanupEnvelopePlacement<'a> {
+    regions: &'a RegionGraph,
+}
+
+impl<'a> HandlerCleanupEnvelopePlacement<'a> {
+    fn apply(regions: &'a RegionGraph, root: SemanticNode) -> Result<SemanticNode, StructureError> {
+        Self { regions }.fold_node(root)
+    }
+
+    fn protects(&self, cleanup: RegionId, handler: RegionId) -> Result<bool, StructureError> {
+        for owner in self.regions.handler_owners(cleanup) {
+            if owner == handler
+                || self
+                    .regions
+                    .tree()
+                    .is_ancestor(handler, owner)
+                    .map_err(StructureError::from)?
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn nest(
+        region: RegionId,
+        body: Box<SemanticNode>,
+        mut catches: Vec<SemanticCatch>,
+        finally: Option<SemanticFinally>,
+    ) -> Result<SemanticNode, StructureError> {
+        let cleanup = catches
+            .pop()
+            .expect("outer cleanup nesting requires one cleanup clause");
+        let cleanup_key = EnvelopeKey {
+            catches: vec![cleanup.region],
+            finally: None,
+        };
+        Self::strip_redundant_cleanup(&mut catches, &cleanup_key)?;
+        let inner = SemanticNode::Try {
+            region,
+            body,
+            catches,
+            finally: None,
+        };
+        Ok(SemanticNode::Try {
+            region,
+            body: Box::new(inner),
+            catches: vec![cleanup],
+            finally,
+        })
+    }
+
+    fn strip_redundant_cleanup(
+        catches: &mut [SemanticCatch],
+        cleanup_key: &EnvelopeKey,
+    ) -> Result<(), StructureError> {
+        for catch in catches {
+            catch.body = StripEnvelopeFamily {
+                key: cleanup_key,
+            }
+            .fold_node(std::mem::replace(&mut catch.body, SemanticNode::Empty))?;
+        }
+        Ok(())
+    }
+}
+
+impl SemanticFolder for HandlerCleanupEnvelopePlacement<'_> {
+    type Error = StructureError;
+
+    fn finish_node(&mut self, node: SemanticNode) -> Result<SemanticNode, Self::Error> {
+        let SemanticNode::Try {
+            region,
+            mut body,
+            catches,
+            finally,
+        } = node
+        else {
+            return Ok(node);
+        };
+        let Some(cleanup) = catches.last().map(|catch| catch.region) else {
+            return Ok(SemanticNode::Try {
+                region,
+                body,
+                catches,
+                finally,
+            });
+        };
+        let cleanup_kind = self
+            .regions
+            .tree()
+            .region(cleanup)
+            .ok_or(StructureError::UnknownRegion(cleanup))?;
+        if finally.is_none()
+            && catches.len() == 1
+            && matches!(&cleanup_kind.kind, crate::ir::RegionKind::Cleanup(_))
+        {
+            if let SemanticNode::Try {
+                catches: inner_catches,
+                ..
+            } = body.as_mut()
+            {
+                let cleanup_key = EnvelopeKey {
+                    catches: vec![cleanup],
+                    finally: None,
+                };
+                Self::strip_redundant_cleanup(inner_catches, &cleanup_key)?;
+            }
+            return Ok(SemanticNode::Try {
+                region,
+                body,
+                catches,
+                finally,
+            });
+        }
+        if finally.is_some()
+            || !matches!(&cleanup_kind.kind, crate::ir::RegionKind::Cleanup(_))
+            || catches.len() < 2
+        {
+            return Ok(SemanticNode::Try {
+                region,
+                body,
+                catches,
+                finally,
+            });
+        }
+        for catch in &catches[..catches.len() - 1] {
+            let kind = self
+                .regions
+                .tree()
+                .region(catch.region)
+                .ok_or(StructureError::UnknownRegion(catch.region))?;
+            if !matches!(&kind.kind, crate::ir::RegionKind::Catch(_))
+                || !self.protects(cleanup, catch.region)?
+            {
+                return Ok(SemanticNode::Try {
+                    region,
+                    body,
+                    catches,
+                    finally,
+                });
+            }
+        }
+        Self::nest(region, body, catches, finally)
+    }
+}
+
 enum EnvelopeSet {
     None,
     One(ExceptionEnvelope),
@@ -1379,6 +1526,51 @@ mod tests {
         );
 
         assert!(envelope.can_wrap(&loop_node(loop_region, SemanticNode::Empty)));
+    }
+
+    #[test]
+    fn repeated_handler_cleanup_wraps_typed_catches() {
+        let region = RegionId::new(1);
+        let typed = RegionId::new(2);
+        let cleanup = RegionId::new(3);
+        let catches = vec![
+            SemanticCatch {
+                region: typed,
+                exception_types: vec![ArgType::object("java/lang/Exception")],
+                exception_value: None,
+                body: envelope(cleanup, SemanticNode::Empty)
+                    .attach(RegionId::new(4), SemanticNode::Empty),
+            },
+            SemanticCatch {
+                region: cleanup,
+                exception_types: vec![ArgType::throwable()],
+                exception_value: None,
+                body: SemanticNode::Empty,
+            },
+        ];
+
+        let nested = HandlerCleanupEnvelopePlacement::nest(
+            region,
+            Box::new(SemanticNode::Empty),
+            catches,
+            None,
+        )
+        .unwrap();
+
+        let SemanticNode::Try {
+            body,
+            catches: outer,
+            ..
+        } = nested
+        else {
+            panic!("cleanup must form an outer try");
+        };
+        assert_eq!(outer[0].region, cleanup);
+        let SemanticNode::Try { catches: inner, .. } = *body else {
+            panic!("typed catches must remain on the inner try");
+        };
+        assert_eq!(inner[0].region, typed);
+        assert!(matches!(inner[0].body, SemanticNode::Empty));
     }
 
     fn synchronized_try_with_catch(

--- a/dexdec/src/ir/structure/region_reducer/envelopes.rs
+++ b/dexdec/src/ir/structure/region_reducer/envelopes.rs
@@ -29,7 +29,12 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
                 .filter_map(|(region, count)| (count > 1).then_some(region))
                 .collect::<Vec<_>>();
             if duplicates.is_empty() {
-                return self.merge_families(root);
+                let root = self.merge_families(root)?;
+                return ExternalMonitorHandlerPlacement::apply(
+                    self.cfg,
+                    self.regions.tree(),
+                    root,
+                );
             }
 
             let mut changed = false;
@@ -50,7 +55,12 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
                 }
             }
             if !changed {
-                return self.merge_families(root);
+                let root = self.merge_families(root)?;
+                return ExternalMonitorHandlerPlacement::apply(
+                    self.cfg,
+                    self.regions.tree(),
+                    root,
+                );
             }
         }
     }
@@ -1083,6 +1093,205 @@ impl SemanticFolder for SynchronizedEnvelopePlacement {
     }
 }
 
+/// A source-level handler outside an explicit synchronized statement runs only
+/// after the synthetic monitor-release handler has completed. Exception-region
+/// partitioning can leave such a handler attached to a try fragment nested in
+/// the recovered synchronized region. Keep the protected fragment, but move
+/// its source handler envelope outside the monitor scope.
+struct ExternalMonitorHandlerPlacement<'cfg, 'tree> {
+    cfg: &'cfg CFG,
+    tree: &'tree crate::ir::RegionTree,
+    changed: bool,
+}
+
+enum ExternalEnvelopePlan {
+    Direct,
+    Sequence(usize),
+}
+
+impl<'cfg, 'tree> ExternalMonitorHandlerPlacement<'cfg, 'tree> {
+    fn apply(
+        cfg: &'cfg CFG,
+        tree: &'tree crate::ir::RegionTree,
+        mut root: SemanticNode,
+    ) -> Result<SemanticNode, StructureError> {
+        loop {
+            let mut placement = Self {
+                cfg,
+                tree,
+                changed: false,
+            };
+            root = placement.fold_node(root)?;
+            if !placement.changed {
+                return Ok(root);
+            }
+        }
+    }
+
+    fn plan(
+        &self,
+        synchronized: RegionId,
+        body: &SemanticNode,
+    ) -> Result<Option<ExternalEnvelopePlan>, StructureError> {
+        if self.external_envelope(synchronized, body)? {
+            return Ok(Some(ExternalEnvelopePlan::Direct));
+        }
+        let SemanticNode::Sequence(nodes) = body else {
+            return Ok(None);
+        };
+        let mut candidate = None;
+        for (index, node) in nodes.iter().enumerate() {
+            if self.external_envelope(synchronized, node)? {
+                let SemanticNode::Try { finally: None, .. } = node else {
+                    return Ok(None);
+                };
+                if candidate.replace(index).is_some() {
+                    return Ok(None);
+                }
+            } else if !self.non_throwing(node) {
+                return Ok(None);
+            }
+        }
+        Ok(candidate.map(ExternalEnvelopePlan::Sequence))
+    }
+
+    fn external_envelope(
+        &self,
+        synchronized: RegionId,
+        node: &SemanticNode,
+    ) -> Result<bool, StructureError> {
+        let SemanticNode::Try {
+            region,
+            catches,
+            finally,
+            ..
+        } = node
+        else {
+            return Ok(false);
+        };
+        if !self
+            .tree
+            .is_ancestor(synchronized, *region)
+            .map_err(StructureError::from)?
+        {
+            return Ok(false);
+        }
+        let handlers = catches
+            .iter()
+            .map(|catch| catch.region)
+            .chain(finally.as_ref().map(|finally| finally.region))
+            .collect::<Vec<_>>();
+        if handlers.is_empty() {
+            return Ok(false);
+        }
+        for handler in handlers {
+            if self
+                .tree
+                .is_ancestor(synchronized, handler)
+                .map_err(StructureError::from)?
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn non_throwing(&self, node: &SemanticNode) -> bool {
+        match node {
+            SemanticNode::Empty => true,
+            SemanticNode::BasicBlock(block) => self.cfg.block(block.id).is_some_and(|source| {
+                source
+                    .insns
+                    .iter()
+                    .all(|instruction| !instruction.can_throw())
+                    && self
+                        .cfg
+                        .successors_with_kind(block.id)
+                        .iter()
+                        .all(|(_, kind)| !kind.is_exception())
+            }),
+            SemanticNode::Sequence(nodes) => nodes.iter().all(|node| self.non_throwing(node)),
+            _ => false,
+        }
+    }
+}
+
+impl SemanticFolder for ExternalMonitorHandlerPlacement<'_, '_> {
+    type Error = StructureError;
+
+    fn finish_node(&mut self, node: SemanticNode) -> Result<SemanticNode, Self::Error> {
+        let SemanticNode::Synchronized {
+            region,
+            lock,
+            method,
+            body,
+        } = node
+        else {
+            return Ok(node);
+        };
+        if method {
+            return Ok(SemanticNode::Synchronized {
+                region,
+                lock,
+                method,
+                body,
+            });
+        }
+        let Some(plan) = self.plan(region, &body)? else {
+            return Ok(SemanticNode::Synchronized {
+                region,
+                lock,
+                method,
+                body,
+            });
+        };
+
+        let (try_region, synchronized_body, catches, finally) = match (plan, *body) {
+            (
+                ExternalEnvelopePlan::Direct,
+                SemanticNode::Try {
+                    region: try_region,
+                    body: try_body,
+                    catches,
+                    finally,
+                },
+            ) => (try_region, *try_body, catches, finally),
+            (ExternalEnvelopePlan::Sequence(index), SemanticNode::Sequence(mut nodes)) => {
+                let SemanticNode::Try {
+                    region: try_region,
+                    body: try_body,
+                    catches,
+                    finally,
+                } = nodes.remove(index)
+                else {
+                    unreachable!("external envelope plan must select a try node");
+                };
+                nodes.insert(index, *try_body);
+                (
+                    try_region,
+                    SemanticNode::sequence(nodes),
+                    catches,
+                    finally,
+                )
+            }
+            _ => unreachable!("external envelope plan must match synchronized body"),
+        };
+
+        self.changed = true;
+        Ok(SemanticNode::Try {
+            region: try_region,
+            body: Box::new(SemanticNode::Synchronized {
+                region,
+                lock,
+                method,
+                body: Box::new(synchronized_body),
+            }),
+            catches,
+            finally,
+        })
+    }
+}
+
 enum EnvelopeSet {
     None,
     One(ExceptionEnvelope),
@@ -1102,7 +1311,11 @@ impl EnvelopeSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{SemanticLeave, SemanticLoopKind, SemanticLoopTest, SemanticPredicate};
+    use crate::ir::{
+        ArgType, Block, CatchRegion, InsnArg, InsnNode, RegionKind, RegisterArg, SemanticBlock,
+        SemanticExpression, SemanticLeave, SemanticLoopKind, SemanticLoopTest, SemanticOperand,
+        SemanticPredicate, SynchronizedRegion,
+    };
 
     fn control_leave(region: RegionId, kind: SemanticLeaveKind) -> SemanticNode {
         SemanticNode::Leave(SemanticLeave {
@@ -1166,5 +1379,100 @@ mod tests {
         );
 
         assert!(envelope.can_wrap(&loop_node(loop_region, SemanticNode::Empty)));
+    }
+
+    fn synchronized_try_with_catch(
+        catch_inside_monitor: bool,
+    ) -> (CFG, crate::ir::RegionTree, SemanticNode) {
+        let mut tree = crate::ir::RegionTree::new(Some(crate::ir::BlockId::new(0)));
+        let root = tree.root();
+        let lock = RegisterArg::new_ssa(0, 0, ArgType::object("java/lang/Object"));
+        let prefix_value = RegisterArg::new_ssa(1, 0, ArgType::INT);
+        let prefix = crate::ir::BlockId::new(4);
+        let mut prefix_block = Block::new(prefix.raw());
+        prefix_block.push(InsnNode::const_val(prefix_value, 0, ArgType::INT));
+        let mut cfg = CFG::new("external_monitor_handler_placement");
+        cfg.entry = prefix;
+        cfg.add_block(prefix_block);
+        let synchronized = tree
+            .add_child(
+                root,
+                RegionKind::Synchronized(SynchronizedRegion {
+                    lock: InsnArg::Reg(lock.clone()),
+                    method: false,
+                    release_handlers: BTreeSet::new(),
+                }),
+                Some(crate::ir::BlockId::new(1)),
+            )
+            .unwrap();
+        let protected = tree
+            .add_child(
+                synchronized,
+                RegionKind::Try,
+                Some(crate::ir::BlockId::new(2)),
+            )
+            .unwrap();
+        let catch_parent = if catch_inside_monitor {
+            synchronized
+        } else {
+            root
+        };
+        let catch = tree
+            .add_child(
+                catch_parent,
+                RegionKind::Catch(CatchRegion {
+                    exception_types: vec![ArgType::object("java/lang/Exception")],
+                    exception_value: None,
+                    continuation: None,
+                }),
+                Some(crate::ir::BlockId::new(3)),
+            )
+            .unwrap();
+        let node = SemanticNode::Synchronized {
+            region: synchronized,
+            lock: SemanticOperand::new(SemanticExpression::Register(lock)),
+            method: false,
+            body: Box::new(SemanticNode::Sequence(vec![
+                SemanticNode::BasicBlock(SemanticBlock {
+                    id: prefix,
+                    statements: Vec::new(),
+                }),
+                SemanticNode::Try {
+                    region: protected,
+                    body: Box::new(SemanticNode::Empty),
+                    catches: vec![SemanticCatch {
+                        region: catch,
+                        exception_types: vec![ArgType::object("java/lang/Exception")],
+                        exception_value: None,
+                        body: SemanticNode::Empty,
+                    }],
+                    finally: None,
+                },
+            ])),
+        };
+        (cfg, tree, node)
+    }
+
+    #[test]
+    fn external_catch_is_hoisted_outside_explicit_synchronization() {
+        let (cfg, tree, node) = synchronized_try_with_catch(false);
+
+        let result = ExternalMonitorHandlerPlacement::apply(&cfg, &tree, node).unwrap();
+        let SemanticNode::Try { body, catches, .. } = result else {
+            panic!("external catch must wrap the monitor scope");
+        };
+        assert_eq!(catches.len(), 1);
+        assert!(matches!(*body, SemanticNode::Synchronized { .. }));
+    }
+
+    #[test]
+    fn catch_inside_synchronization_stays_inside_monitor_scope() {
+        let (cfg, tree, node) = synchronized_try_with_catch(true);
+
+        let result = ExternalMonitorHandlerPlacement::apply(&cfg, &tree, node).unwrap();
+        let SemanticNode::Synchronized { body, .. } = result else {
+            panic!("internal catch must stay inside the monitor scope");
+        };
+        assert!(matches!(*body, SemanticNode::Sequence(_)));
     }
 }

--- a/dexdec/src/ir/structure/region_reducer/envelopes.rs
+++ b/dexdec/src/ir/structure/region_reducer/envelopes.rs
@@ -43,7 +43,7 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
                 };
                 let candidate = canonicalizer.fold_node(root)?;
                 let region_changed = canonicalizer.changed;
-                if region_changed && LexicalLabels::escaped_loop(&candidate).is_some() {
+                if region_changed && escapes_structured_control(&candidate) {
                     root = original;
                 } else {
                     root = candidate;
@@ -76,7 +76,7 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
                 let original = root.clone();
                 let mut family_changed = false;
                 let candidate = self.merge_family(root, family, &mut family_changed)?;
-                if family_changed && LexicalLabels::escaped_loop(&candidate).is_some() {
+                if family_changed && escapes_structured_control(&candidate) {
                     root = original;
                 } else {
                     root = candidate;
@@ -344,7 +344,7 @@ impl<'a> ExceptionEnvelopeCanonicalizer<'a> {
         let body = self.strip(node, target)?;
         let region = self.envelope_owner(target, &envelope)?;
         let candidate = self.place_envelope(body, region, envelope)?;
-        if LexicalLabels::escaped_loop(&candidate).is_some() {
+        if escapes_structured_control(&candidate) {
             return Ok(original);
         }
         *changed = true;
@@ -639,7 +639,7 @@ impl SemanticFolder for MergeEnvelopeFamily<'_, '_, '_, '_> {
         let original = node.clone();
         let body = self.canonicalizer.strip_family(node, &self.family.key)?;
         let candidate = self.canonicalizer.place_envelope(body, region, envelope)?;
-        if LexicalLabels::escaped_loop(&candidate).is_some() {
+        if escapes_structured_control(&candidate) {
             return Ok(SemanticFoldControl::Descend(original));
         }
 
@@ -841,6 +841,12 @@ impl ExceptionEnvelope {
                 })
             && self.finally.as_ref().map(|finally| finally.region)
                 == other.finally.as_ref().map(|finally| finally.region)
+            // Catch/finally continuations are part of envelope identity. A loop
+            // may rewrite BreakLabel into Break(region) inside its body; merging
+            // that rewritten catch onto a try outside the loop leaves the break
+            // targeting inactive control.
+            && self.label_dependencies() == other.label_dependencies()
+            && self.control_dependencies() == other.control_dependencies()
     }
 
     fn can_wrap(&self, node: &SemanticNode) -> bool {
@@ -1017,6 +1023,14 @@ struct FreeControlDependencies {
     free: BTreeSet<RegionId>,
 }
 
+impl FreeControlDependencies {
+    fn collect(node: &SemanticNode) -> BTreeSet<RegionId> {
+        let mut dependencies = Self::default();
+        dependencies.visit_node(node);
+        dependencies.free
+    }
+}
+
 impl SemanticVisitor for FreeControlDependencies {
     fn enter_node(&mut self, node: &SemanticNode) {
         if let Some(region) = ControlBindings::binding(node) {
@@ -1045,6 +1059,14 @@ impl SemanticVisitor for FreeControlDependencies {
             self.active.remove(&region);
         }
     }
+}
+
+/// True when a candidate envelope placement leaves a loop label or region
+/// break/continue without an active binder — the same class of defect as
+/// `LexicalLabels::escaped_loop`, for region-controlled loops.
+fn escapes_structured_control(root: &SemanticNode) -> bool {
+    LexicalLabels::escaped_loop(root).is_some()
+        || !FreeControlDependencies::collect(root).is_empty()
 }
 
 struct SynchronizedEnvelopePlacement {
@@ -1264,12 +1286,7 @@ impl SemanticFolder for ExternalMonitorHandlerPlacement<'_, '_> {
                     unreachable!("external envelope plan must select a try node");
                 };
                 nodes.insert(index, *try_body);
-                (
-                    try_region,
-                    SemanticNode::sequence(nodes),
-                    catches,
-                    finally,
-                )
+                (try_region, SemanticNode::sequence(nodes), catches, finally)
             }
             _ => unreachable!("external envelope plan must match synchronized body"),
         };
@@ -1350,10 +1367,8 @@ impl<'a> HandlerCleanupEnvelopePlacement<'a> {
         cleanup_key: &EnvelopeKey,
     ) -> Result<(), StructureError> {
         for catch in catches {
-            catch.body = StripEnvelopeFamily {
-                key: cleanup_key,
-            }
-            .fold_node(std::mem::replace(&mut catch.body, SemanticNode::Empty))?;
+            catch.body = StripEnvelopeFamily { key: cleanup_key }
+                .fold_node(std::mem::replace(&mut catch.body, SemanticNode::Empty))?;
         }
         Ok(())
     }
@@ -1511,6 +1526,42 @@ mod tests {
 
         assert!(!envelope.can_wrap(&loop_node(loop_region, SemanticNode::Empty)));
         assert!(envelope.can_wrap(&loop_node(RegionId::new(3), SemanticNode::Empty,)));
+    }
+
+    #[test]
+    fn envelope_shape_includes_handler_control_dependencies() {
+        let loop_region = RegionId::new(1);
+        let handler_region = RegionId::new(2);
+        let label = SemanticLabel::block(RegionId::new(4), crate::ir::BlockId::new(88));
+        let with_break = envelope(
+            handler_region,
+            control_leave(loop_region, SemanticLeaveKind::Break),
+        );
+        let with_break_label = envelope(
+            handler_region,
+            SemanticNode::Leave(SemanticLeave {
+                site: None,
+                condition: None,
+                kind: SemanticLeaveKind::BreakLabel(label),
+                edge: None,
+                origin: None,
+                source: handler_region,
+                destination: RegionId::new(4),
+                target: RegionId::new(4),
+                cleanup: Vec::new(),
+            }),
+        );
+
+        assert!(!with_break.same_shape(&with_break_label));
+        assert!(escapes_structured_control(
+            &with_break
+                .clone()
+                .attach(RegionId::new(5), SemanticNode::Empty,)
+        ));
+        assert!(!escapes_structured_control(&loop_node(
+            loop_region,
+            with_break.attach(RegionId::new(5), SemanticNode::Empty),
+        )));
     }
 
     #[test]

--- a/dexdec/src/ir/structure/region_reducer/handlers.rs
+++ b/dexdec/src/ir/structure/region_reducer/handlers.rs
@@ -8,7 +8,7 @@ use crate::ir::{
 };
 
 use super::super::{
-    continuation::{ContinuationBinding, ControlPort, ControlTransfer},
+    continuation::{ContinuationBinding, ContinuationPort, ControlPort, ControlTransfer},
     StructureError,
 };
 use super::region_cfg::RegionCfg;
@@ -169,6 +169,49 @@ struct ExceptionValueSubstitution {
     thrown: RegisterArg,
 }
 
+struct ForwardedHandlerBody {
+    port: ContinuationPort,
+    body: SemanticNode,
+    replacements: usize,
+}
+
+impl ForwardedHandlerBody {
+    fn inline(
+        adapter: SemanticNode,
+        port: ContinuationPort,
+        body: SemanticNode,
+    ) -> Result<Option<SemanticNode>, StructureError> {
+        let mut forwarding = Self {
+            port,
+            body,
+            replacements: 0,
+        };
+        let candidate = forwarding
+            .fold_node(adapter)
+            .map_err(StructureError::from)?;
+        Ok((forwarding.replacements == 1).then_some(candidate))
+    }
+}
+
+impl SemanticFolder for ForwardedHandlerBody {
+    type Error = crate::ir::SemanticFoldError;
+
+    fn finish_node(&mut self, node: SemanticNode) -> Result<SemanticNode, Self::Error> {
+        let SemanticNode::Leave(leave) = &node else {
+            return Ok(node);
+        };
+        let target = match &leave.kind {
+            SemanticLeaveKind::FallThrough(target) | SemanticLeaveKind::Jump(target) => *target,
+            _ => return Ok(node),
+        };
+        if leave.target != self.port.scope || target != self.port.target {
+            return Ok(node);
+        }
+        self.replacements += 1;
+        Ok(self.body.clone())
+    }
+}
+
 impl SemanticExpressionTransform for ExceptionValueSubstitution {
     fn transform_register(&mut self, register: RegisterArg) -> SemanticExpression {
         if SsaVar::from_reg(&register) == Some(self.caught) {
@@ -292,6 +335,7 @@ impl<'a> HandlerReducer<'a> {
                 RegionKind::Catch(catch) => {
                     let body_region = self.body_region(owner, *child)?;
                     let (reduction, alternate) = self.reduction(reduced, body_region)?;
+                    let reduction = self.inline_forwarded_catch(*child, reduction, reduced)?;
                     envelope.catches.push(SemanticCatch {
                         region: *child,
                         exception_types: catch.exception_types,
@@ -363,6 +407,83 @@ impl<'a> HandlerReducer<'a> {
             }
         }
         Ok(HandlerContraction { envelope, ports })
+    }
+
+    /// DEX can split one source catch into register-state adapters that enter
+    /// a shared lexical body. Once exception analysis proves that relation,
+    /// retain the adapter path but bind its sole continuation to the already
+    /// reduced ancestor catch instead of exposing the body entry to the
+    /// enclosing ordinary control-flow graph.
+    fn inline_forwarded_catch(
+        &self,
+        handler: RegionId,
+        reduction: ReducedPort,
+        reduced: &BTreeMap<RegionId, ReducedRegion>,
+    ) -> Result<ReducedPort, StructureError> {
+        let Some((target_handler, target)) = self.forwarded_catch_target(handler)? else {
+            return Ok(reduction);
+        };
+        let forwarding = ContinuationPort {
+            scope: target_handler,
+            target,
+        };
+        if reduction.continuations.ports().len() != 1
+            || !reduction.continuations.ports().contains(&forwarding)
+            || !reduction.continuations.controls().is_empty()
+        {
+            return Ok(reduction);
+        }
+        let Some(target_body) = reduced
+            .get(&target_handler)
+            .and_then(|reduction| reduction.ports.get(&target))
+        else {
+            return Ok(reduction);
+        };
+        let original = reduction.body;
+        let Some(body) =
+            ForwardedHandlerBody::inline(original.clone(), forwarding, target_body.body.clone())?
+        else {
+            return Ok(ReducedPort::new(original));
+        };
+        Ok(ReducedPort::new(body))
+    }
+
+    pub(super) fn forwarded_catch_target(
+        &self,
+        handler: RegionId,
+    ) -> Result<Option<(RegionId, crate::ir::BlockId)>, StructureError> {
+        let tree = self.regions.tree();
+        let descriptor = tree
+            .region(handler)
+            .ok_or(StructureError::UnknownRegion(handler))?;
+        let RegionKind::Catch(source_catch) = &descriptor.kind else {
+            return Ok(None);
+        };
+        let Some(entry) = descriptor.entry else {
+            return Ok(None);
+        };
+        let Some(target) = self.regions.handler_adapters().get(&entry).copied() else {
+            return Ok(None);
+        };
+        let Some(target_handler) = self.regions.owner_of(target) else {
+            return Ok(None);
+        };
+        if !tree
+            .is_ancestor(target_handler, handler)
+            .map_err(|_| StructureError::UnknownRegion(target_handler))?
+        {
+            return Ok(None);
+        }
+        let target_descriptor = tree
+            .region(target_handler)
+            .ok_or(StructureError::UnknownRegion(target_handler))?;
+        let RegionKind::Catch(target_catch) = &target_descriptor.kind else {
+            return Ok(None);
+        };
+        Ok((target_descriptor.entry == Some(target)
+            && source_catch.exception_types == target_catch.exception_types
+            && source_catch.exception_value == target_catch.exception_value)
+            .then_some((target_handler, target)))
     }
 
     fn source_finally_body(
@@ -543,5 +664,75 @@ impl<'a> HandlerReducer<'a> {
         }
         .ok_or(StructureError::MissingControlTarget(port.target))?;
         Ok(Some((port, target)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{ForwardedHandlerBody, SemanticNode};
+    use crate::ir::structure::continuation::{ContinuationFacts, ContinuationPort};
+    use crate::ir::{BlockId, RegionId, SemanticBlock, SemanticLeave, SemanticLeaveKind};
+
+    fn fallthrough(scope: RegionId, target: BlockId) -> SemanticNode {
+        SemanticNode::Leave(SemanticLeave {
+            site: None,
+            condition: None,
+            kind: SemanticLeaveKind::FallThrough(target),
+            edge: None,
+            origin: None,
+            source: scope,
+            destination: scope,
+            target: scope,
+            cleanup: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn forwarded_handler_body_replaces_the_adapter_continuation() {
+        let handler = RegionId::new(5);
+        let enclosing = RegionId::new(0);
+        let entry = BlockId::new(65);
+        let continuation = BlockId::new(70);
+        let port = ContinuationPort {
+            scope: handler,
+            target: entry,
+        };
+        let adapter = SemanticNode::sequence([
+            SemanticNode::BasicBlock(SemanticBlock {
+                id: BlockId::new(58),
+                statements: Vec::new(),
+            }),
+            fallthrough(handler, entry),
+        ]);
+        let body = SemanticNode::sequence([
+            SemanticNode::BasicBlock(SemanticBlock {
+                id: entry,
+                statements: Vec::new(),
+            }),
+            fallthrough(enclosing, continuation),
+        ]);
+
+        let inlined = ForwardedHandlerBody::inline(adapter.clone(), port, body)
+            .expect("forwarding rewrite")
+            .expect("one matching adapter continuation");
+        assert_eq!(
+            ContinuationFacts::analyze(&inlined).ports(),
+            &BTreeSet::from([ContinuationPort {
+                scope: enclosing,
+                target: continuation,
+            }])
+        );
+        assert!(ForwardedHandlerBody::inline(
+            adapter,
+            ContinuationPort {
+                scope: handler,
+                target: BlockId::new(66),
+            },
+            SemanticNode::Empty,
+        )
+        .expect("non-matching rewrite")
+        .is_none());
     }
 }

--- a/dexdec/src/language/java/source_types.rs
+++ b/dexdec/src/language/java/source_types.rs
@@ -214,7 +214,8 @@ impl<'a> JavaTypeRelations<'a> {
                 .or_else(|| {
                     self.hierarchy
                         .and_then(|hierarchy| hierarchy.erasure_of(ty))
-                }),
+                })
+                .or_else(|| Self::synthesized_class_erasure(class)),
             JavaType::Variable(variable) => self
                 .variable_erasures
                 .get(variable)
@@ -225,6 +226,34 @@ impl<'a> JavaTypeRelations<'a> {
                 .iter()
                 .find_map(|(erased, source)| (source == ty).then(|| erased.clone())),
         }
+    }
+
+    /// Recover a DEX binary name for a raw class that never entered `source_types`.
+    ///
+    /// Platform interfaces reached only through check-cast / select targets are
+    /// often present as `JavaType::Class` without an indexed erasure. Package
+    /// segments with plain source identifiers map back to `a/b/C` binary names.
+    fn synthesized_class_erasure(class: &JavaClassType) -> Option<ArgType> {
+        if class.segments.is_empty()
+            || class
+                .segments
+                .iter()
+                .any(|segment| !segment.arguments.is_empty())
+        {
+            return None;
+        }
+        let mut path = String::new();
+        for (index, segment) in class.segments.iter().enumerate() {
+            let name = segment.name.as_str();
+            if name.is_empty() || name.starts_with("$dex$") {
+                return None;
+            }
+            if index > 0 {
+                path.push('/');
+            }
+            path.push_str(name);
+        }
+        Some(ArgType::object(&path))
     }
 
     pub(super) fn is_assignable(&self, source: &JavaType, target: &JavaType) -> bool {
@@ -5865,6 +5894,19 @@ mod tests {
                 None,
             ),
             Some(JavaTypeArgument::Any),
+        );
+    }
+
+    #[test]
+    fn unindexed_platform_interface_synthesizes_class_erasure() {
+        let source_types = BTreeMap::new();
+        let variables = BTreeMap::new();
+        let relations = JavaTypeRelations::new(&source_types, &variables, None);
+        let ty = JavaType::source_class("android.content.ComponentCallbacks2");
+
+        assert_eq!(
+            relations.erasure_of(&ty),
+            Some(ArgType::object("android/content/ComponentCallbacks2"))
         );
     }
 


### PR DESCRIPTION
## Summary

- close declared synchronized method scopes and rejoin catches that were split around monitors
- recover split finally families, bind forwarded catch bodies, and treat cleanup forwarding into enclosing finally as a rethrow
- place phi copies on cleanup ingress edges and preserve prior values across exception edges
- keep release-handler subtrees, enclosing try ancestors, and monitor entries aligned after catch continuations are stripped
- enter the outermost loop when its header is shared with a nested try, and synthesize class erasure for unindexed raw select targets

This is one exception-cleanup and synchronization-region pipeline presented as 29 scoped commits. `bind straight-line cleanup state` is intentionally omitted: stacked on the current main it regresses `syncWithFinally` return values, so it stays on the remaining ledger.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- `cargo test -p dexdec --lib` (523 passed)
- 31 added regression scenarios
- non-corpus `dexdec` integration targets passed
- `node --test scripts/version.test.mjs` and `node scripts/version.mjs check`
- full-class Java decompilation on an anonymized production DEX shard: 4043/4043 classes succeeded with zero failures; the generated file set matches the previous main snapshot, with 29 files changed

## Baseline comparisons

- the external corpus target retains the same single pre-existing snapshot mismatch on base and candidate
- this change does not touch the GUI MCP packages

## Review notes

The commits follow exception cleanup, SSA copies, finally recovery, then synchronized region nesting, so they can be reviewed in order. Rebased onto current `main` after #17 and #18 merged.