### PR TITLE
Drop vacuous predicates and keep required phi copy sources

### DIFF
--- a/dexdec/src/analysis/value_recovery/flow.rs
+++ b/dexdec/src/analysis/value_recovery/flow.rs
@@ -217,6 +217,17 @@ impl SsaCopyFlow {
         value
     }
 
+    fn omitted_source(&self, mut value: SsaVar) -> SsaVar {
+        let mut visited = BTreeSet::new();
+        while self.omitted.contains(&value) && visited.insert(value) {
+            let Some(source) = self.sources.get(&value).copied() else {
+                break;
+            };
+            value = source;
+        }
+        value
+    }
+
     fn argument(&self, value: SsaVar) -> InsnArg {
         InsnArg::reg_ssa(
             value.reg_num,
@@ -431,8 +442,13 @@ impl<'ir> ValueFlowGraph<'ir> {
             };
             for input in &phi.inputs {
                 self.retained_phi_inputs.insert(input.value);
+                let source = self.copies.omitted_source(input.value);
+                self.retained_phi_inputs.insert(source);
                 if excluded.contains_key(&input.value) {
                     pending.push(input.value);
+                }
+                if source != input.value && excluded.contains_key(&source) {
+                    pending.push(source);
                 }
             }
         }
@@ -800,35 +816,52 @@ impl<'ir> ValueFlowGraph<'ir> {
     }
 
     fn required_phi_inputs(&self) -> BTreeSet<SsaVar> {
-        let phis = self
-            .phis
-            .iter()
-            .map(|phi| (phi.result, phi))
-            .collect::<BTreeMap<_, _>>();
-        let mut pending = self
+        let pending = self
             .phis
             .iter()
             .filter(|phi| self.has_reaching_use(phi.result))
             .map(|phi| phi.result)
             .collect::<Vec<_>>();
-        let mut required = self.retained_phi_inputs.clone();
-        let mut visited = BTreeSet::new();
-        while let Some(result) = pending.pop() {
-            if !visited.insert(result) {
-                continue;
+        required_phi_input_closure(
+            &self.phis,
+            &self.copies,
+            pending,
+            self.retained_phi_inputs.clone(),
+        )
+    }
+}
+
+fn required_phi_input_closure(
+    phis: &[PhiMerge],
+    copies: &SsaCopyFlow,
+    mut pending: Vec<SsaVar>,
+    mut required: BTreeSet<SsaVar>,
+) -> BTreeSet<SsaVar> {
+    let phis = phis
+        .iter()
+        .map(|phi| (phi.result, phi))
+        .collect::<BTreeMap<_, _>>();
+    let mut visited = BTreeSet::new();
+    while let Some(result) = pending.pop() {
+        if !visited.insert(result) {
+            continue;
+        }
+        let Some(phi) = phis.get(&result) else {
+            continue;
+        };
+        for input in &phi.inputs {
+            required.insert(input.value);
+            let source = copies.omitted_source(input.value);
+            required.insert(source);
+            if phis.contains_key(&input.value) {
+                pending.push(input.value);
             }
-            let Some(phi) = phis.get(&result) else {
-                continue;
-            };
-            for input in &phi.inputs {
-                required.insert(input.value);
-                if phis.contains_key(&input.value) {
-                    pending.push(input.value);
-                }
+            if source != input.value && phis.contains_key(&source) {
+                pending.push(source);
             }
         }
-        required
     }
+    required
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -875,8 +908,10 @@ impl SemanticVisitor for ControlSymbolClosure {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::analysis::PhiInput;
     use crate::ir::{
-        InsnNode, InsnType, InstructionId, RegionId, SemanticCatch, SemanticExpression,
+        BlockId, EdgeKind, InsnNode, InsnType, InstructionId, RegionId, SemanticCatch,
+        SemanticExpression,
     };
 
     fn operation(
@@ -944,5 +979,39 @@ mod tests {
             ValueFlowGraph::build_source(&SemanticNode::Empty, &BTreeSet::from([binding])).unwrap();
 
         assert!(graph.is_bound(binding));
+    }
+
+    #[test]
+    fn required_phi_inputs_retain_transitive_copy_sources() {
+        let headers = SsaVar::new(12, 1);
+        let handler_copy = SsaVar::new(13, 3);
+        let null = SsaVar::new(13, 0);
+        let merged = SsaVar::new(13, 4);
+        let phis = vec![PhiMerge {
+            block: BlockId::new(113),
+            instruction: InstructionId::new(200),
+            result: merged,
+            inputs: vec![
+                PhiInput {
+                    predecessor: BlockId::new(108),
+                    edge_kind: EdgeKind::Normal,
+                    value: handler_copy,
+                },
+                PhiInput {
+                    predecessor: BlockId::new(110),
+                    edge_kind: EdgeKind::Normal,
+                    value: null,
+                },
+            ],
+        }];
+        let mut copies = SsaCopyFlow::default();
+        copies.sources.insert(handler_copy, headers);
+        copies.omitted.insert(handler_copy);
+
+        let required = required_phi_input_closure(&phis, &copies, vec![merged], BTreeSet::new());
+
+        assert!(required.contains(&handler_copy));
+        assert!(required.contains(&headers));
+        assert!(required.contains(&null));
     }
 }

--- a/dexdec/src/ir/region/control.rs
+++ b/dexdec/src/ir/region/control.rs
@@ -40,6 +40,12 @@ impl ControlCandidate {
         let closure = ControlRegionClosure::new(cfg, facts, tree, handlers, entry, &domain);
         let blocks = closure.close(&blocks, matches!(&kind, RegionKind::Loop(_)))?;
         Self::refresh_loop_follow(cfg, facts, &mut kind, &blocks);
+        // Domain clipping can drop the header when it sits outside the lexical
+        // owner of the body (e.g. loop header above a nested try). Inserting
+        // that truncated region would leave `entry` outside `blocks`.
+        if !blocks.contains(&entry) {
+            return Ok(());
+        }
         if Self::already_inserted(tree, &kind, entry, &blocks) {
             return Ok(());
         }
@@ -55,6 +61,9 @@ impl ControlCandidate {
                 let closure = ControlRegionClosure::new(cfg, facts, tree, handlers, entry, &domain);
                 let core = closure.close(&core, matches!(&kind, RegionKind::Loop(_)))?;
                 Self::refresh_loop_follow(cfg, facts, &mut kind, &core);
+                if !core.contains(&entry) {
+                    return Ok(());
+                }
                 let placement = if Self::foreign_entries(facts, entry, &core).is_empty() {
                     tree.insert_laminar_region(kind, entry, core)?
                 } else {

--- a/dexdec/src/ir/region/tree.rs
+++ b/dexdec/src/ir/region/tree.rs
@@ -1462,6 +1462,13 @@ impl SynchronizationPlacement {
                             cfg.block(*block)
                                 .map(|block| (block.offset, block.id.raw()))
                                 .unwrap_or((u32::MAX, block.raw()))
+                        })
+                        .or_else(|| {
+                            remaining.iter().copied().min_by_key(|block| {
+                                cfg.block(*block)
+                                    .map(|block| (block.offset, block.id.raw()))
+                                    .unwrap_or((u32::MAX, block.raw()))
+                            })
                         });
                 }
             }

--- a/dexdec/src/ir/semantic.rs
+++ b/dexdec/src/ir/semantic.rs
@@ -1018,16 +1018,28 @@ impl SemanticNode {
     }
 
     pub fn guard(condition: SemanticPredicate, node: SemanticNode) -> Self {
-        if condition.constant_value() == Some(true) || matches!(node, Self::Empty) {
-            node
-        } else if condition.constant_value() == Some(false) {
-            Self::Empty
-        } else {
-            Self::If {
-                condition: SemanticOperand::new(condition),
-                then_node: Box::new(node),
-                else_node: None,
+        match condition.constant_value() {
+            Some(true) => return node,
+            Some(false) => return Self::Empty,
+            None => {}
+        }
+        if matches!(node, Self::Empty) {
+            // Vacuous branches must still evaluate effectful predicates.
+            // Value recovery can inline invokes into `If` conditions and leave
+            // both arms empty; dropping the condition would erase those effects.
+            if condition.effects().is_pure() {
+                return Self::Empty;
             }
+            return Self::If {
+                condition: SemanticOperand::new(condition),
+                then_node: Box::new(Self::Empty),
+                else_node: None,
+            };
+        }
+        Self::If {
+            condition: SemanticOperand::new(condition),
+            then_node: Box::new(node),
+            else_node: None,
         }
     }
 
@@ -1042,7 +1054,17 @@ impl SemanticNode {
             None => {}
         }
         match (then_node, else_node) {
-            (Self::Empty, None | Some(Self::Empty)) => Self::Empty,
+            (Self::Empty, None | Some(Self::Empty)) => {
+                if condition.effects().is_pure() {
+                    Self::Empty
+                } else {
+                    Self::If {
+                        condition: SemanticOperand::new(condition),
+                        then_node: Box::new(Self::Empty),
+                        else_node: None,
+                    }
+                }
+            }
             (Self::Empty, Some(else_node)) => Self::guard(condition.negate(), else_node),
             (then_node, None | Some(Self::Empty)) => Self::guard(condition, then_node),
             (then_node, Some(else_node)) => Self::If {
@@ -1051,6 +1073,70 @@ impl SemanticNode {
                 else_node: Some(Box::new(else_node)),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod branch_effect_tests {
+    use super::*;
+    use crate::ir::{
+        ArgType, InstructionId, InvokeType, LiteralArg, MemberReference, MethodDescriptor,
+        MethodReference,
+    };
+
+    fn invoke_predicate() -> SemanticPredicate {
+        let mut instruction = InsnNode::new(InsnType::Invoke, 0);
+        instruction.id = InstructionId::new(1);
+        instruction.payload.invoke_type = Some(InvokeType::Virtual);
+        instruction.payload.reference = Some(MemberReference::Method(MethodReference {
+            owner: ArgType::object("java/util/ArrayList"),
+            name: "remove".into(),
+            descriptor: MethodDescriptor {
+                parameters: vec![ArgType::object("java/lang/Object")],
+                return_type: ArgType::BOOLEAN,
+            },
+        }));
+        instruction.result = Some(RegisterArg::new_ssa(0, 0, ArgType::BOOLEAN));
+        let operation = SemanticOperation::from_instruction(instruction).expect("invoke");
+        SemanticPredicate::Test(operation)
+    }
+
+    #[test]
+    fn branch_keeps_effectful_predicate_when_arms_are_empty() {
+        let node = SemanticNode::branch(invoke_predicate(), SemanticNode::Empty, None);
+        match node {
+            SemanticNode::If {
+                condition,
+                then_node,
+                else_node,
+            } => {
+                assert!(matches!(then_node.as_ref(), SemanticNode::Empty));
+                assert!(else_node.is_none());
+                assert!(!condition.value.effects().is_pure());
+            }
+            other => panic!("expected vacuous if, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_drops_pure_predicate_when_arms_are_empty() {
+        let mut instruction = InsnNode::new(InsnType::If, 0);
+        instruction.id = InstructionId::new(2);
+        instruction.payload.if_op = Some(IfOp::Ne);
+        let operation = SemanticOperation::from_parts(
+            instruction,
+            vec![
+                SemanticExpression::Register(RegisterArg::new_ssa(1, 0, ArgType::INT)),
+                SemanticExpression::Literal(LiteralArg::int(0)),
+            ],
+            None,
+        );
+        let node = SemanticNode::branch(
+            SemanticPredicate::Test(operation),
+            SemanticNode::Empty,
+            None,
+        );
+        assert!(matches!(node, SemanticNode::Empty));
     }
 }
 

--- a/dexdec/src/ir/semantic/normalize.rs
+++ b/dexdec/src/ir/semantic/normalize.rs
@@ -735,9 +735,142 @@ impl SemanticFolder for SourceSemanticNormalizer {
             SemanticNode::BasicBlock(block) if block.statements.is_empty() => SemanticNode::Empty,
             node => node,
         };
+        let node = RedundantVacuousPredicate::rewrite(node);
         let node = BranchLinearizer::rewrite(node);
         let node = TryLexicalScope::extend(node);
         SemanticNormalizer::new(ReachabilityMode::PruneUnreachable).finish_node(node)
+    }
+}
+
+/// Remove a vacuous predicate when source-value recovery has transferred its
+/// evaluation into the immediately following condition.
+///
+/// The shared instruction identity is important: two bytecode comparisons
+/// that happen to look alike must still be emitted twice. We also require the
+/// replay to occur before any other effect in the following condition so that
+/// deleting the stale evaluation cannot reorder throws or side effects.
+struct RedundantVacuousPredicate;
+
+impl RedundantVacuousPredicate {
+    fn rewrite(node: SemanticNode) -> SemanticNode {
+        let SemanticNode::Sequence(nodes) = node else {
+            return node;
+        };
+        let redundant = nodes
+            .windows(2)
+            .map(|pair| {
+                Self::vacuous_test_id(&pair[0])
+                    .is_some_and(|test| Self::node_replays_before_effects(&pair[1], test))
+            })
+            .chain(std::iter::once(false))
+            .collect::<Vec<_>>();
+        let retained = nodes
+            .into_iter()
+            .zip(redundant)
+            .filter_map(|(node, redundant)| (!redundant).then_some(node));
+        SemanticNode::sequence(retained)
+    }
+
+    fn vacuous_test_id(node: &SemanticNode) -> Option<crate::ir::InstructionId> {
+        let SemanticNode::If {
+            condition,
+            then_node,
+            else_node: None,
+        } = node
+        else {
+            return None;
+        };
+        if !matches!(then_node.as_ref(), SemanticNode::Empty) {
+            return None;
+        }
+        Self::single_test_id(condition)
+    }
+
+    fn single_test_id(predicate: &SemanticPredicate) -> Option<crate::ir::InstructionId> {
+        let operation = match predicate {
+            SemanticPredicate::Test(operation) => operation,
+            SemanticPredicate::Not(inner) => return Self::single_test_id(inner),
+            SemanticPredicate::True
+            | SemanticPredicate::False
+            | SemanticPredicate::And(_)
+            | SemanticPredicate::Or(_) => return None,
+        };
+        operation.id.is_valid().then_some(operation.id)
+    }
+
+    fn node_replays_before_effects(node: &SemanticNode, target: crate::ir::InstructionId) -> bool {
+        match node {
+            SemanticNode::If { condition, .. } => {
+                Self::predicate_replays_before_effects(condition, target)
+            }
+            SemanticNode::Empty
+            | SemanticNode::Sequence(_)
+            | SemanticNode::BasicBlock(_)
+            | SemanticNode::Loop { .. }
+            | SemanticNode::For { .. }
+            | SemanticNode::ForEach { .. }
+            | SemanticNode::Switch { .. }
+            | SemanticNode::Try { .. }
+            | SemanticNode::Synchronized { .. }
+            | SemanticNode::Label { .. }
+            | SemanticNode::Leave(_) => false,
+        }
+    }
+
+    fn predicate_replays_before_effects(
+        predicate: &SemanticPredicate,
+        target: crate::ir::InstructionId,
+    ) -> bool {
+        if Self::single_test_id(predicate) == Some(target) {
+            return true;
+        }
+        match predicate {
+            SemanticPredicate::Test(operation) => {
+                let Ok(operands) = operation.evaluation_operands() else {
+                    return false;
+                };
+                for operand in operands {
+                    if Self::expression_replays_before_effects(operand, target) {
+                        return true;
+                    }
+                    if !operand.effects().is_pure() {
+                        return false;
+                    }
+                }
+                false
+            }
+            SemanticPredicate::Not(inner) => Self::predicate_replays_before_effects(inner, target),
+            SemanticPredicate::And(terms) | SemanticPredicate::Or(terms) => terms
+                .first()
+                .is_some_and(|term| Self::predicate_replays_before_effects(term, target)),
+            SemanticPredicate::True | SemanticPredicate::False => false,
+        }
+    }
+
+    fn expression_replays_before_effects(
+        expression: &SemanticExpression,
+        target: crate::ir::InstructionId,
+    ) -> bool {
+        match expression {
+            SemanticExpression::Register(_) | SemanticExpression::Literal(_) => false,
+            SemanticExpression::Select { condition, .. } => {
+                Self::predicate_replays_before_effects(condition, target)
+            }
+            SemanticExpression::Operation(operation) => {
+                let Ok(operands) = operation.evaluation_operands() else {
+                    return false;
+                };
+                for operand in operands {
+                    if Self::expression_replays_before_effects(operand, target) {
+                        return true;
+                    }
+                    if !operand.effects().is_pure() {
+                        return false;
+                    }
+                }
+                false
+            }
+        }
     }
 }
 
@@ -1537,5 +1670,94 @@ impl SemanticSize {
 impl SemanticVisitor for SemanticSize {
     fn enter_node(&mut self, _node: &SemanticNode) {
         self.nodes = self.nodes.saturating_add(1);
+    }
+}
+
+#[cfg(test)]
+mod redundant_vacuous_predicate_tests {
+    use super::*;
+    use crate::ir::{
+        ArgType, IfOp, InsnNode, InsnType, InstructionId, InvokeType, LiteralArg, RegisterArg,
+        SemanticOperand, SemanticOperation,
+    };
+
+    fn invoke_predicate(id: usize) -> SemanticPredicate {
+        let mut instruction = InsnNode::new(InsnType::Invoke, 0);
+        instruction.id = InstructionId::new(id);
+        instruction.payload.invoke_type = Some(InvokeType::Static);
+        instruction.result = Some(RegisterArg::new_ssa(0, id as u32, ArgType::BOOLEAN));
+        SemanticPredicate::Test(SemanticOperation::from_parts(instruction, Vec::new(), None))
+    }
+
+    fn replaying_predicate(
+        id: usize,
+        replayed: SemanticPredicate,
+        prefix: Option<SemanticExpression>,
+    ) -> SemanticPredicate {
+        let selected = SemanticExpression::select(
+            replayed,
+            SemanticExpression::Literal(LiteralArg::int(0)),
+            SemanticExpression::Literal(LiteralArg::int(1)),
+        );
+        let mut operands = Vec::new();
+        operands.extend(prefix);
+        operands.push(selected);
+        operands.push(SemanticExpression::Literal(LiteralArg::int(0)));
+        let mut instruction = InsnNode::new(InsnType::If, 0);
+        instruction.id = InstructionId::new(id);
+        instruction.payload.if_op = Some(IfOp::Eq);
+        SemanticPredicate::Test(SemanticOperation::from_parts(instruction, operands, None))
+    }
+
+    fn vacuous(condition: SemanticPredicate) -> SemanticNode {
+        SemanticNode::If {
+            condition: SemanticOperand::new(condition),
+            then_node: Box::new(SemanticNode::Empty),
+            else_node: None,
+        }
+    }
+
+    #[test]
+    fn removes_vacuous_predicate_replayed_by_following_condition() {
+        let predicate = invoke_predicate(1);
+        let following = vacuous(replaying_predicate(2, predicate.clone(), None));
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate),
+            following,
+        ]));
+
+        let SemanticNode::If { condition, .. } = rewritten else {
+            panic!("expected only the following condition, got {rewritten:?}");
+        };
+        assert_eq!(
+            RedundantVacuousPredicate::single_test_id(&condition),
+            Some(InstructionId::new(2))
+        );
+    }
+
+    #[test]
+    fn keeps_vacuous_predicate_without_a_replay() {
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(invoke_predicate(1)),
+            vacuous(invoke_predicate(2)),
+        ]));
+
+        assert!(matches!(rewritten, SemanticNode::Sequence(nodes) if nodes.len() == 2));
+    }
+
+    #[test]
+    fn keeps_vacuous_predicate_when_an_effect_precedes_the_replay() {
+        let predicate = invoke_predicate(1);
+        let prefix = SemanticExpression::Operation(Box::new(match invoke_predicate(3) {
+            SemanticPredicate::Test(operation) => operation,
+            _ => unreachable!(),
+        }));
+        let following = vacuous(replaying_predicate(2, predicate.clone(), Some(prefix)));
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate),
+            following,
+        ]));
+
+        assert!(matches!(rewritten, SemanticNode::Sequence(nodes) if nodes.len() == 2));
     }
 }

--- a/dexdec/src/language/java/dex.rs
+++ b/dexdec/src/language/java/dex.rs
@@ -4588,6 +4588,14 @@ impl JavaDialect for DexJavaDialect {
         };
         let ty = self
             .source_register_type(register)
+            // A source variable can span disjoint DEX register lifetimes. Do
+            // not let an earlier primitive lifetime type a reference-valued
+            // enhanced-for binding (or vice versa).
+            .filter(|source| {
+                let source_is_primitive = matches!(source, JavaType::Primitive(_));
+                !(source_is_primitive && binding_type.is_reference()
+                    || !source_is_primitive && binding_type.is_primitive())
+            })
             .cloned()
             .map(Ok)
             .unwrap_or_else(|| self.source_type(binding_type))?;
@@ -4887,6 +4895,73 @@ impl JavaDialect for DexJavaDialect {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use crate::ir::analysis::SourceTypeEnvironment;
+    use crate::ir::{ArgType, RegisterArg};
+
+    use super::{DexJavaDialect, JavaDialect, JavaMemberNames, JavaType};
+
+    #[test]
+    fn foreach_binding_ignores_a_reused_primitive_source_variable_type() {
+        let erased = ArgType::object("java/util/ArrayList");
+        let reference = JavaType::source_class("java.util.ArrayList");
+        let mut dialect = DexJavaDialect::new(
+            true,
+            None,
+            &[],
+            &[],
+            &SourceTypeEnvironment::default(),
+            BTreeMap::from([(erased.clone(), reference.clone())]),
+            Arc::new(JavaMemberNames::default()),
+        )
+        .expect("static dialect");
+        dialect.source_variable_types.insert(6, JavaType::int());
+        let register = RegisterArg {
+            reg_num: 1,
+            ty: erased,
+            ssa_version: Some(3),
+            code_var: Some(6),
+        };
+
+        let (ty, _) = JavaDialect::loop_variable(&mut dialect, &register)
+            .expect("reference-valued foreach binding");
+
+        assert_eq!(ty, reference);
+    }
+
+    #[test]
+    fn foreach_binding_keeps_a_reference_source_type_over_object_erasure() {
+        let erased = ArgType::object("java/lang/Object");
+        let reference = JavaType::source_class("example.Element");
+        let mut dialect = DexJavaDialect::new(
+            true,
+            None,
+            &[],
+            &[],
+            &SourceTypeEnvironment::default(),
+            BTreeMap::from([(erased.clone(), JavaType::source_class("java.lang.Object"))]),
+            Arc::new(JavaMemberNames::default()),
+        )
+        .expect("static dialect");
+        dialect.source_variable_types.insert(6, reference.clone());
+        let register = RegisterArg {
+            reg_num: 1,
+            ty: erased,
+            ssa_version: Some(3),
+            code_var: Some(6),
+        };
+
+        let (ty, _) =
+            JavaDialect::loop_variable(&mut dialect, &register).expect("reference source type");
+
+        assert_eq!(ty, reference);
     }
 }
 

--- a/dexdec/src/language/java/syntax/mod.rs
+++ b/dexdec/src/language/java/syntax/mod.rs
@@ -4,6 +4,7 @@ mod conditions;
 mod expression;
 mod loops;
 pub(super) mod primitives;
+mod protection;
 
 use crate::analysis::SemanticTransform;
 use crate::ir::{analysis::TypeHierarchy, SemanticMethod, SourceSemantics, SourceSyntaxSemantics};
@@ -12,6 +13,7 @@ pub struct SourceSyntaxRecovery<'a> {
     expressions: expression::ExpressionSyntax,
     loops: loops::JavaLoopSyntax<'a>,
     conditions: conditions::PathConditionSyntax,
+    protection: protection::ProtectionSyntax<'a>,
 }
 
 pub struct JavaValueSyntax<'a> {
@@ -44,6 +46,7 @@ impl<'a> SourceSyntaxRecovery<'a> {
             expressions: expression::ExpressionSyntax::default(),
             loops: loops::JavaLoopSyntax::new(hierarchy),
             conditions: conditions::PathConditionSyntax,
+            protection: protection::ProtectionSyntax::new(hierarchy),
         }
     }
 }
@@ -65,6 +68,7 @@ impl SemanticTransform<SourceSemantics> for SourceSyntaxRecovery<'_> {
         self.loops.apply(method.body_mut())?;
         let types = method.state().types().clone();
         self.conditions.apply(method.body_mut(), &types)?;
+        self.protection.apply(method.body_mut())?;
         Ok(method.into_source_syntax())
     }
 }

--- a/dexdec/src/language/java/syntax/protection.rs
+++ b/dexdec/src/language/java/syntax/protection.rs
@@ -1,0 +1,129 @@
+use crate::ir::{
+    analysis::{SubtypeRelation, TypeHierarchy},
+    ArgType, SemanticFoldError, SemanticFolder, SemanticNode,
+};
+
+/// Normalizes DEX exception-handler groups to legal Java catch alternatives.
+///
+/// DEX permits related catch types to target the same handler. Java multi-catch
+/// does not: no alternative may be a subtype of another. Since every type in a
+/// grouped handler has the same body, a strictly narrower alternative is
+/// redundant and can be removed without changing which code executes.
+pub(super) struct ProtectionSyntax<'a> {
+    hierarchy: &'a dyn TypeHierarchy,
+    changed: bool,
+}
+
+impl<'a> ProtectionSyntax<'a> {
+    pub(super) fn new(hierarchy: &'a dyn TypeHierarchy) -> Self {
+        Self {
+            hierarchy,
+            changed: false,
+        }
+    }
+
+    pub(super) fn apply(&mut self, root: &mut SemanticNode) -> Result<bool, SemanticFoldError> {
+        self.changed = false;
+        let body = std::mem::replace(root, SemanticNode::Empty);
+        *root = self.fold_node(body)?;
+        Ok(self.changed)
+    }
+
+    fn is_strict_subtype(&self, candidate: &ArgType, alternative: &ArgType) -> bool {
+        let (Some(candidate), Some(alternative)) = (candidate.as_object(), alternative.as_object())
+        else {
+            return false;
+        };
+        self.hierarchy.subtype_relation(candidate, alternative) == SubtypeRelation::Yes
+            && self.hierarchy.subtype_relation(alternative, candidate) != SubtypeRelation::Yes
+    }
+
+    fn normalize_types(&mut self, types: &mut Vec<ArgType>) {
+        if types.len() < 2 {
+            return;
+        }
+        let original = types.clone();
+        types.retain(|candidate| {
+            !original.iter().any(|alternative| {
+                candidate != alternative && self.is_strict_subtype(candidate, alternative)
+            })
+        });
+        self.changed |= types.len() != original.len();
+    }
+}
+
+impl SemanticFolder for ProtectionSyntax<'_> {
+    type Error = SemanticFoldError;
+
+    fn finish_node(&mut self, mut node: SemanticNode) -> Result<SemanticNode, Self::Error> {
+        if let SemanticNode::Try { catches, .. } = &mut node {
+            for catch in catches {
+                self.normalize_types(&mut catch.exception_types);
+            }
+        }
+        Ok(node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::analysis::ClassHierarchyIndex;
+
+    fn throwable_hierarchy() -> ClassHierarchyIndex {
+        let mut hierarchy = ClassHierarchyIndex::default();
+        hierarchy.add("java/lang/Throwable", vec!["java/lang/Object".to_string()]);
+        hierarchy.add("java/lang/Error", vec!["java/lang/Throwable".to_string()]);
+        hierarchy.add(
+            "java/lang/VirtualMachineError",
+            vec!["java/lang/Error".to_string()],
+        );
+        hierarchy.add(
+            "java/lang/OutOfMemoryError",
+            vec!["java/lang/VirtualMachineError".to_string()],
+        );
+        hierarchy.add(
+            "java/lang/Exception",
+            vec!["java/lang/Throwable".to_string()],
+        );
+        hierarchy.add(
+            "java/io/IOException",
+            vec!["java/lang/Exception".to_string()],
+        );
+        hierarchy
+    }
+
+    #[test]
+    fn removes_related_multi_catch_alternative() {
+        let hierarchy = throwable_hierarchy();
+        let mut syntax = ProtectionSyntax::new(&hierarchy);
+        let mut types = vec![
+            ArgType::object("java/lang/Error"),
+            ArgType::object("java/lang/OutOfMemoryError"),
+        ];
+
+        syntax.normalize_types(&mut types);
+
+        assert_eq!(types, vec![ArgType::object("java/lang/Error")]);
+    }
+
+    #[test]
+    fn keeps_unrelated_multi_catch_alternatives() {
+        let hierarchy = throwable_hierarchy();
+        let mut syntax = ProtectionSyntax::new(&hierarchy);
+        let mut types = vec![
+            ArgType::object("java/io/IOException"),
+            ArgType::object("java/lang/Error"),
+        ];
+
+        syntax.normalize_types(&mut types);
+
+        assert_eq!(
+            types,
+            vec![
+                ArgType::object("java/io/IOException"),
+                ArgType::object("java/lang/Error"),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- skip clipped control regions and harden try-entry repair
- keep effectful predicates when both `if` arms are empty, and drop replayed vacuous predicates
- remove related multi-catch alternatives that cannot fire
- retain omitted phi copy sources required by later uses
- reject stale primitive types on foreach source bindings

This is one semantic-normalization and type-binding pipeline presented as 6 scoped commits. Two earlier exception-cleanup commits stay on the remaining ledger because they regress structured `finally` / `syncWithFinally` output when stacked on current main.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- `cargo test -p dexdec --lib` (533 passed)
- 10 added regression scenarios
- `cargo test -p dexdec --test expected_test`

## Review notes

The commits are ordered from region-entry repair through predicate folding to Java type cleanup, so they can be reviewed in order without mixing the remaining Java control-flow emission work.