### PR TITLE
Recover Java switch emission and preserve colliding source outputs

### DIFF
--- a/dexdec/src/analysis/java_backend/anonymous_lowering.rs
+++ b/dexdec/src/analysis/java_backend/anonymous_lowering.rs
@@ -2168,8 +2168,9 @@ impl AnonymousInstance {
             values: captures,
             identity: candidate.identity.as_ref(),
             value_types,
+            substitute_this: true,
         }
-        .rewrite_anonymous_body(&mut body);
+        .rewrite_root_anonymous_body(&mut body);
         if let Some(identity) = candidate.identity.as_ref() {
             AnonymousIdentitySubstitution { identity }.rewrite_anonymous_body(&mut body);
         }
@@ -2655,9 +2656,19 @@ struct CaptureSubstitution<'a> {
     values: BTreeMap<JavaIdentifier, JavaExpr>,
     identity: Option<&'a JavaType>,
     value_types: &'a BTreeMap<JavaIdentifier, LexicalValueType>,
+    // A nested anonymous body's `this` owns a separate field namespace. Its
+    // explicit QualifiedThis references can still target this capture owner.
+    substitute_this: bool,
 }
 
 impl JavaAstRewriter for CaptureSubstitution<'_> {
+    fn rewrite_anonymous_body(&mut self, body: &mut JavaAnonymousClassBody) {
+        let substitute_this = self.substitute_this;
+        self.substitute_this = false;
+        self.rewrite_anonymous_members(body);
+        self.substitute_this = substitute_this;
+    }
+
     fn finish_expression(&mut self, expression: JavaExpr) -> JavaExpr {
         match expression {
             JavaExpr::Cast { ty, value }
@@ -2668,7 +2679,7 @@ impl JavaAstRewriter for CaptureSubstitution<'_> {
                 *value
             }
             JavaExpr::Field { owner, name }
-                if matches!(owner.as_ref(), JavaExpr::This)
+                if self.substitute_this && matches!(owner.as_ref(), JavaExpr::This)
                     || matches!(
                         (owner.as_ref(), self.identity),
                         (JavaExpr::QualifiedThis(owner), Some(identity)) if owner == identity
@@ -2685,6 +2696,36 @@ impl JavaAstRewriter for CaptureSubstitution<'_> {
 }
 
 impl CaptureSubstitution<'_> {
+    fn rewrite_root_anonymous_body(&mut self, body: &mut JavaAnonymousClassBody) {
+        self.rewrite_anonymous_members(body);
+    }
+
+    fn rewrite_anonymous_members(&mut self, body: &mut JavaAnonymousClassBody) {
+        for field in &mut body.fields {
+            self.rewrite_annotations(&mut field.annotations);
+            field.initializer = field
+                .initializer
+                .take()
+                .map(|value| self.rewrite_expression(value));
+        }
+        for method in &mut body.methods {
+            self.rewrite_annotations(&mut method.annotations);
+            for parameter in &mut method.parameters {
+                self.rewrite_annotations(&mut parameter.annotations);
+            }
+            if let Some(body) = &mut method.body {
+                self.rewrite_body(body);
+            }
+        }
+        let substitute_this = self.substitute_this;
+        self.substitute_this = false;
+        for nested in &mut body.nested {
+            self.rewrite_type_declaration(nested);
+        }
+        self.substitute_this = substitute_this;
+        self.finish_anonymous_body(body);
+    }
+
     fn capture_type(&self, expression: &JavaExpr) -> Option<&LexicalValueType> {
         match expression {
             JavaExpr::Name(name) if self.values.values().any(|captured| captured == expression) => {
@@ -2703,5 +2744,82 @@ impl CaptureSubstitution<'_> {
             (JavaType::Variable(left), JavaType::Variable(right)) => left == right,
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod capture_substitution_tests {
+    use super::*;
+    use crate::language::java::JavaFieldDeclaration;
+
+    fn field(name: &str, initializer: JavaExpr) -> JavaFieldDeclaration {
+        JavaFieldDeclaration {
+            annotations: Vec::new(),
+            modifiers: Vec::new(),
+            ty: JavaType::Class(JavaClassType::from_source("java.lang.Object")),
+            name: JavaIdentifier::from_dex(name),
+            initializer: Some(initializer),
+        }
+    }
+
+    #[test]
+    fn captured_field_substitution_stops_at_nested_anonymous_body() {
+        let captured = JavaIdentifier::from_dex("captured");
+        let direct_reference = JavaExpr::Field {
+            owner: Box::new(JavaExpr::This),
+            name: captured.clone(),
+        };
+        let nested_reference = direct_reference.clone();
+        let identity = JavaType::Class(JavaClassType::from_source("example.ParentAnonymous"));
+        let enclosing_reference = JavaExpr::Field {
+            owner: Box::new(JavaExpr::QualifiedThis(identity.clone())),
+            name: captured.clone(),
+        };
+        let nested_body = JavaAnonymousClassBody {
+            fields: vec![
+                field("nestedUse", nested_reference.clone()),
+                field("enclosingUse", enclosing_reference),
+            ],
+            methods: Vec::new(),
+            nested: Vec::new(),
+        };
+        let mut body = JavaAnonymousClassBody {
+            fields: vec![
+                field("directUse", direct_reference),
+                field(
+                    "nested",
+                    JavaExpr::New {
+                        enclosing: None,
+                        ty: JavaType::Class(JavaClassType::from_source("example.Listener")),
+                        target_type: None,
+                        args: Vec::new(),
+                        anonymous_body: Some(Box::new(nested_body)),
+                    },
+                ),
+            ],
+            methods: Vec::new(),
+            nested: Vec::new(),
+        };
+        let replacement = JavaExpr::Name(JavaIdentifier::from_dex("value"));
+        let value_types = BTreeMap::new();
+
+        CaptureSubstitution {
+            values: BTreeMap::from([(captured, replacement.clone())]),
+            identity: Some(&identity),
+            value_types: &value_types,
+            substitute_this: true,
+        }
+        .rewrite_root_anonymous_body(&mut body);
+
+        assert_eq!(body.fields[0].initializer, Some(replacement.clone()));
+        let Some(JavaExpr::New {
+            anonymous_body: Some(nested),
+            ..
+        }) = body.fields[1].initializer.as_ref()
+        else {
+            panic!("expected nested anonymous body");
+        };
+        assert_eq!(nested.fields[0].initializer, Some(nested_reference));
+        assert_eq!(nested.fields[1].initializer, Some(replacement));
     }
 }

--- a/dexdec/src/analysis/java_backend/declaration_lowering.rs
+++ b/dexdec/src/analysis/java_backend/declaration_lowering.rs
@@ -582,9 +582,10 @@ impl<'a> JavaTypeLowering<'a> {
             .ok_or(JavaDecompilerError::MalformedDeclarationStack)?;
         let mut declaration = lowered.declaration;
         let recovered_functions = lowered.liveness.apply(&mut declaration);
-        let outer_aliases = self
-            .outer_instances
-            .iter()
+        // Resolved simple owner names can collide across unrelated classes;
+        // only aliases owned by this lexical model may rewrite its fields.
+        let outer_aliases = class
+            .outer_instances()
             .map(|(field, outer)| {
                 Ok((
                     self.names.resolve_type(&field.owner)?,

--- a/dexdec/src/analysis/java_backend/java_model/method.rs
+++ b/dexdec/src/analysis/java_backend/java_model/method.rs
@@ -498,7 +498,9 @@ impl JavaMethodDeclaration {
             && parsed_signature.as_ref().is_some_and(|signature| {
                 signature.has_unbound_type_variables(lexical_type_variables)
             });
-        let explicit_signature = parsed_signature.filter(|_| !has_unbound_variables);
+        let explicit_signature = parsed_signature.filter(|signature| {
+            !has_unbound_variables && method_signature_is_java_denotable(signature)
+        });
         let (signature, source_return_type) = match explicit_signature {
             Some(signature) => (Some(signature), None),
             None => {
@@ -660,6 +662,24 @@ impl JavaMethodDeclaration {
     }
 }
 
+fn method_signature_is_java_denotable(
+    signature: &crate::ir::generic_types::MethodSignature,
+) -> bool {
+    signature.type_parameters.iter().all(|parameter| {
+        parameter
+            .class_bound
+            .iter()
+            .chain(&parameter.interface_bounds)
+            .all(|bound| {
+                !matches!(
+                    bound,
+                    crate::ir::generic_types::JvmTypeSignature::Array(_)
+                        | crate::ir::generic_types::JvmTypeSignature::BaseType(_)
+                )
+            })
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::analysis::java_backend) enum JavaMethodDeclarationKind {
     Method,
@@ -800,4 +820,31 @@ fn is_meaningful_param_name(name: &str) -> bool {
         return false;
     }
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ir::generic_types::GenericSignatures;
+
+    use super::method_signature_is_java_denotable;
+
+    #[test]
+    fn rejects_an_array_type_parameter_bound_in_a_method_signature() {
+        let signature = GenericSignatures::method(
+            "<C:[Ljava/lang/Object;:TR;R:Ljava/lang/Object;>\
+             (TC;Lkotlin/jvm/functions/Function0<+TR;>;)TR;",
+        )
+        .expect("Kotlin array intersection signature");
+
+        assert!(!method_signature_is_java_denotable(&signature));
+    }
+
+    #[test]
+    fn accepts_a_java_denotable_method_signature() {
+        let signature =
+            GenericSignatures::method("<T:Ljava/lang/Object;>(Ljava/util/List<+TT;>;)TT;")
+                .expect("ordinary generic method signature");
+
+        assert!(method_signature_is_java_denotable(&signature));
+    }
 }

--- a/dexdec/src/analysis/java_backend/java_model/method.rs
+++ b/dexdec/src/analysis/java_backend/java_model/method.rs
@@ -3,7 +3,7 @@ use crate::ir::{ty::ArgType, CFG};
 use crate::language::java::{
     AggregateInitializer, DefiniteAssignment, JavaAstNormalizer, JavaAstTransform, JavaIdentifier,
     JavaInitializerExitLowering, JavaLowerer, JavaMethodCompletion, JavaModifier, JavaType,
-    LexicalDeclarationPlacement,
+    JavaVoidTailLinearizer, LexicalDeclarationPlacement,
 };
 
 use super::super::method_pipeline::MethodBodyAnalysis;
@@ -324,6 +324,15 @@ impl JavaMethodBody {
                 .apply(&mut ast)
                 .map_err(crate::language::java::JavaLoweringError::from)
         })?;
+        if !class_initializer && self.return_type.as_ref() == Some(&ArgType::VOID) {
+            let mut tail = JavaVoidTailLinearizer;
+            crate::profile_scope!("java_backend.method_lower.void_tail", {
+                match tail.apply(&mut ast) {
+                    Ok(_) => {}
+                    Err(never) => match never {},
+                }
+            });
+        }
         if semantically_terminal {
             if let Some(return_type) = completion_type {
                 let mut completion = JavaMethodCompletion::new(return_type);

--- a/dexdec/src/analysis/java_backend/java_model/source_abi.rs
+++ b/dexdec/src/analysis/java_backend/java_model/source_abi.rs
@@ -63,6 +63,10 @@ pub(in crate::analysis::java_backend) struct OuterInstanceField {
 }
 
 impl OuterInstanceField {
+    pub(in crate::analysis::java_backend) fn reference(&self) -> &FieldReference {
+        &self.reference
+    }
+
     /// Proves the enclosing-instance field from constructor def-use rather
     /// than field names or type uniqueness. This is required for local and
     /// anonymous classes, where another captured value can have the same type

--- a/dexdec/src/analysis/java_backend/member_names.rs
+++ b/dexdec/src/analysis/java_backend/member_names.rs
@@ -2,7 +2,7 @@
 
 use crate::ir::{ArgType, MethodDescriptor};
 use crate::language::java::{
-    JavaConstructorLayout, JavaFieldSymbol, JavaMemberNames, JavaMethodSymbol,
+    JavaConstructorLayout, JavaFieldSymbol, JavaIdentifier, JavaMemberNames, JavaMethodSymbol,
 };
 
 use super::java_model::method::{JavaMethodDeclarationKind, JavaMethodModel};
@@ -13,6 +13,7 @@ pub(super) struct ClassMemberNames;
 impl ClassMemberNames {
     pub(super) fn collect(root: &JavaClassModel) -> JavaMemberNames {
         let mut fields = Vec::new();
+        let mut hidden_fields = Vec::new();
         let mut methods = Vec::new();
         let mut constructors = Vec::new();
         let mut pending = vec![root];
@@ -23,6 +24,14 @@ impl ClassMemberNames {
             };
             fields.extend(class.fields.iter().map(|field| {
                 JavaFieldSymbol::new(owner.clone(), field.name.clone(), field.field_type.clone())
+            }));
+            hidden_fields.extend(class.outer_instance.iter().map(|outer| {
+                let field = outer.reference();
+                JavaFieldSymbol::new(
+                    field.owner.clone(),
+                    JavaIdentifier::from_dex(&field.name),
+                    field.field_type.clone(),
+                )
             }));
             methods.extend(
                 class
@@ -37,7 +46,9 @@ impl ClassMemberNames {
                     .filter_map(|method| Self::constructor(owner.clone(), method)),
             );
         }
-        JavaMemberNames::allocate(fields, methods).with_constructor_layouts(constructors)
+        JavaMemberNames::allocate(fields, methods)
+            .with_hidden_fields(hidden_fields)
+            .with_constructor_layouts(constructors)
     }
 
     pub(super) fn method_only(

--- a/dexdec/src/analysis/value_recovery/flow.rs
+++ b/dexdec/src/analysis/value_recovery/flow.rs
@@ -73,6 +73,7 @@ struct UseFact {
     repetitive: bool,
     evaluation_prefix: EffectSummary,
     context: UseContext,
+    consumer: Option<InsnType>,
     site: Option<UseSite>,
 }
 

--- a/dexdec/src/analysis/value_recovery/flow/collector.rs
+++ b/dexdec/src/analysis/value_recovery/flow/collector.rs
@@ -2,8 +2,9 @@ use std::{borrow::Cow, cell::RefCell, sync::Arc};
 
 use crate::ir::semantic::{CompletionDomain, CompletionInterpreter};
 use crate::ir::{
-    SemanticExpression, SemanticLabel, SemanticLeave, SemanticLoopControl, SemanticLoopKind,
-    SemanticNode, SemanticOperation, SemanticPredicate, SemanticStatement, SemanticStatementKind,
+    InsnType, SemanticExpression, SemanticLabel, SemanticLeave, SemanticLoopControl,
+    SemanticLoopKind, SemanticNode, SemanticOperation, SemanticPredicate, SemanticStatement,
+    SemanticStatementKind,
 };
 
 use super::{
@@ -228,6 +229,7 @@ impl<'ir> FlowCollector<'ir> {
                     event,
                     prefix,
                     UseContext::Value,
+                    None,
                     argument_site,
                     origin,
                 )
@@ -297,6 +299,7 @@ impl<'ir> FlowCollector<'ir> {
             event,
             &mut prefix,
             UseContext::Value,
+            None,
             site,
             origin,
         )?;
@@ -404,6 +407,7 @@ impl<'ir> FlowCollector<'ir> {
             event,
             &mut prefix,
             UseContext::Value,
+            None,
             site,
             origin,
         )?;
@@ -427,11 +431,11 @@ impl<'ir> FlowCollector<'ir> {
                 .evaluation_operands()?
                 .into_iter()
                 .rev()
-                .map(EvaluationTask::Expression),
+                .map(|expression| EvaluationTask::Expression(expression, operation.insn_type)),
         );
         while let Some(task) = pending.pop() {
             match task {
-                EvaluationTask::Expression(SemanticExpression::Register(register)) => {
+                EvaluationTask::Expression(SemanticExpression::Register(register), consumer) => {
                     if let Some(key) = self.graph.key(register) {
                         self.graph.uses.entry(key).or_default().push(UseFact {
                             point: origin.cloned(),
@@ -443,25 +447,31 @@ impl<'ir> FlowCollector<'ir> {
                             repetitive: self.repetitive_depth != 0,
                             evaluation_prefix: prefix.clone(),
                             context,
+                            consumer: Some(consumer),
                             site,
                         });
                     }
                 }
-                EvaluationTask::Expression(SemanticExpression::Operation(child)) => {
+                EvaluationTask::Expression(SemanticExpression::Operation(child), _) => {
                     pending.push(EvaluationTask::Effect(child));
                     pending.extend(
                         child
                             .evaluation_operands()?
                             .into_iter()
                             .rev()
-                            .map(EvaluationTask::Expression),
+                            .map(|expression| {
+                                EvaluationTask::Expression(expression, child.insn_type)
+                            }),
                     );
                 }
-                EvaluationTask::Expression(SemanticExpression::Select {
-                    condition,
-                    when_true,
-                    when_false,
-                }) => {
+                EvaluationTask::Expression(
+                    SemanticExpression::Select {
+                        condition,
+                        when_true,
+                        when_false,
+                    },
+                    consumer,
+                ) => {
                     *prefix = prefix
                         .clone()
                         .join(self.visit_predicate_uses(condition, domain, event, site, origin)?);
@@ -476,6 +486,7 @@ impl<'ir> FlowCollector<'ir> {
                         event,
                         &mut true_prefix,
                         context,
+                        Some(consumer),
                         site,
                         origin,
                     )?;
@@ -486,12 +497,13 @@ impl<'ir> FlowCollector<'ir> {
                         event,
                         &mut false_prefix,
                         context,
+                        Some(consumer),
                         site,
                         origin,
                     )?;
                     *prefix = true_prefix.join(false_prefix);
                 }
-                EvaluationTask::Expression(SemanticExpression::Literal(_)) => {}
+                EvaluationTask::Expression(SemanticExpression::Literal(_), _) => {}
                 EvaluationTask::Effect(operation) => {
                     *prefix = prefix.clone().join(EffectSummary::direct(operation));
                 }
@@ -507,6 +519,7 @@ impl<'ir> FlowCollector<'ir> {
         event: usize,
         prefix: &mut EffectSummary,
         context: UseContext,
+        consumer: Option<InsnType>,
         site: Option<UseSite>,
         origin: Option<&crate::ir::analysis::SemanticFlowPoint>,
     ) -> Result<(), ValueRecoveryError> {
@@ -524,6 +537,7 @@ impl<'ir> FlowCollector<'ir> {
                         repetitive: self.repetitive_depth != 0,
                         evaluation_prefix: prefix.clone(),
                         context,
+                        consumer,
                         site,
                     });
                 }
@@ -551,6 +565,7 @@ impl<'ir> FlowCollector<'ir> {
                     event,
                     &mut true_prefix,
                     context,
+                    consumer,
                     site,
                     origin,
                 )?;
@@ -561,6 +576,7 @@ impl<'ir> FlowCollector<'ir> {
                     event,
                     &mut false_prefix,
                     context,
+                    consumer,
                     site,
                     origin,
                 )?;
@@ -791,6 +807,6 @@ enum FlowTask<'a> {
 }
 
 enum EvaluationTask<'a> {
-    Expression(&'a SemanticExpression),
+    Expression(&'a SemanticExpression, InsnType),
     Effect(&'a SemanticOperation),
 }

--- a/dexdec/src/analysis/value_recovery/flow/planner.rs
+++ b/dexdec/src/analysis/value_recovery/flow/planner.rs
@@ -1314,6 +1314,19 @@ impl<'a> ValuePlanner<'a> {
         let [usage] = uses else {
             return Ok(false);
         };
+        // A materialized DEX `cmpg`/`cmpl` is lowered with explicit NaN bias
+        // and may inspect each operand more than once. Keep effectful operand
+        // producers as locals until the comparison itself can be rewritten as
+        // a source predicate; predicate operands are single-evaluated there.
+        if usage.consumer == Some(InsnType::Cmp) && usage.context != UseContext::Predicate {
+            let Some(effect) = self.relocatable_definition_effect_with_dependencies(definition)
+            else {
+                return Ok(false);
+            };
+            if !effect.is_pure() {
+                return Ok(false);
+            }
+        }
         if self.adjacent_inline(definition, usage)? {
             return Ok(true);
         }
@@ -1781,6 +1794,67 @@ impl<'a> ValuePlanner<'a> {
         }
     }
 
+    /// Includes effects hidden behind SSA registers in an expression. A pure
+    /// arithmetic wrapper can still contain an unstable producer (for example
+    /// `getCurrentScale() * factor`); expanding that wrapper into a materialized
+    /// `cmpg`/`cmpl` would evaluate the producer more than once.
+    fn relocatable_definition_effect_with_dependencies(
+        &self,
+        definition: &DefinitionFact,
+    ) -> Option<EffectSummary> {
+        let mut effect = EffectSummary::expression(definition.expression());
+        let mut pending = vec![definition.expression()];
+        let mut visited = BTreeSet::new();
+        while let Some(expression) = pending.pop() {
+            match expression {
+                SemanticExpression::Register(register) => {
+                    let Some(key) = self.graph().key(register) else {
+                        continue;
+                    };
+                    if !visited.insert(key) {
+                        continue;
+                    }
+                    let Some(definitions) = self.graph().definitions.get(&key) else {
+                        continue;
+                    };
+                    for dependency in definitions {
+                        effect = effect.join(EffectSummary::expression(dependency.expression()));
+                        pending.push(dependency.expression());
+                    }
+                }
+                SemanticExpression::Operation(operation) => {
+                    pending.extend(operation.operands());
+                    pending.extend(operation.compound_target());
+                }
+                SemanticExpression::Select {
+                    condition,
+                    when_true,
+                    when_false,
+                } => {
+                    pending.push(when_true);
+                    pending.push(when_false);
+                    let mut predicates = vec![condition];
+                    while let Some(predicate) = predicates.pop() {
+                        match predicate {
+                            crate::ir::SemanticPredicate::Test(operation) => {
+                                effect = effect.join(EffectSummary::operation(operation));
+                                pending.extend(operation.operands());
+                                pending.extend(operation.compound_target());
+                            }
+                            crate::ir::SemanticPredicate::Not(inner) => predicates.push(inner),
+                            crate::ir::SemanticPredicate::And(terms)
+                            | crate::ir::SemanticPredicate::Or(terms) => predicates.extend(terms),
+                            crate::ir::SemanticPredicate::True
+                            | crate::ir::SemanticPredicate::False => {}
+                        }
+                    }
+                }
+                SemanticExpression::Literal(_) => {}
+            }
+        }
+        effect.can_relocate().then_some(effect)
+    }
+
     fn selection_effect(definition: &DefinitionFact) -> EffectSummary {
         match definition.operation() {
             Some(operation) if operation.payload.edge_copy => {
@@ -1885,9 +1959,10 @@ impl ValueAction {
 mod tests {
     use super::*;
     use crate::ir::{
-        analysis::SsaValueGraph, block::Block, ArgType, BlockId, EdgeKind, InsnNode, InvokeType,
-        RegionId, RegisterArg, SemanticBlock, SemanticLoopControl, SemanticLoopKind,
-        SemanticLoopTest, SemanticNode, SemanticPredicate, SemanticStatement, CFG,
+        analysis::SsaValueGraph, block::Block, ArgType, ArithOp, BlockId, CmpBias, EdgeKind,
+        InsnNode, InvokeType, RegionId, RegisterArg, SemanticBlock, SemanticLoopControl,
+        SemanticLoopKind, SemanticLoopTest, SemanticNode, SemanticPredicate, SemanticStatement,
+        CFG,
     };
 
     fn register(value: SsaVar, ty: &ArgType) -> RegisterArg {
@@ -1998,6 +2073,35 @@ mod tests {
         assert!(scheduled.contains(&allocation));
         assert!(scheduled.contains(&first_alias));
         assert!(scheduled.contains(&second_alias));
+    }
+
+    #[test]
+    fn keeps_pure_cmp_wrapper_when_its_dependency_reads_memory() {
+        let float_type = ArgType::FLOAT;
+        let field_value = SsaVar::new(1, 0);
+        let product = SsaVar::new(2, 0);
+        let comparison = SsaVar::new(3, 0);
+
+        let mut block = Block::new(0u32);
+        block.push(InsnNode::sget(register(field_value, &float_type), 7));
+        block.push(InsnNode::arith(
+            ArithOp::Mul,
+            register(product, &float_type),
+            argument(field_value, &float_type),
+            InsnArg::lit(0x3f800000, float_type.clone()),
+            float_type.clone(),
+        ));
+        block.push(InsnNode::cmp(
+            register(comparison, &ArgType::INT),
+            argument(product, &float_type),
+            InsnArg::lit(0x3f800000, float_type),
+            CmpBias::Gt,
+        ));
+
+        let scheduled = scheduled_replacements("cmp_dependency_read", block);
+
+        assert!(scheduled.contains(&field_value));
+        assert!(!scheduled.contains(&product));
     }
 
     #[test]

--- a/dexdec/src/cli/decompile.rs
+++ b/dexdec/src/cli/decompile.rs
@@ -1,6 +1,6 @@
 //! Source generation for one method, selected classes, or a complete archive.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -76,6 +76,7 @@ impl DecompileCommand {
         let requested = classes.len();
         let mut results = Vec::with_capacity(requested);
         let mut failures = Vec::new();
+        let mut output_paths = SourceOutputPaths::default();
         for (index, class) in classes.iter().enumerate() {
             context.progress(&format!(
                 "[{}/{}] decompile {}",
@@ -108,7 +109,7 @@ impl DecompileCommand {
                 Err(error) => return Err(error.into()),
             };
             let output_path = if let Some(directory) = request.output_dir.as_deref() {
-                let path = prepare_file_path(&directory.join(&unit.path));
+                let path = prepare_file_path(&directory.join(output_paths.claim(&unit.path)));
                 match context.host_mut().write(&path, unit.source.as_bytes()) {
                     Ok(()) => Some(path),
                     Err(error) if !request.fail_fast => {
@@ -284,6 +285,48 @@ impl DecompileCommand {
     }
 }
 
+#[derive(Default)]
+struct SourceOutputPaths {
+    exact: BTreeMap<PathBuf, PathBuf>,
+    portable: BTreeSet<String>,
+}
+
+impl SourceOutputPaths {
+    fn claim(&mut self, requested: &Path) -> PathBuf {
+        if let Some(path) = self.exact.get(requested) {
+            return path.clone();
+        }
+        let portable = Self::portable_key(requested);
+        if self.portable.insert(portable) {
+            let path = requested.to_path_buf();
+            self.exact.insert(path.clone(), path.clone());
+            return path;
+        }
+        let Some(file_name) = requested.file_name() else {
+            return requested.to_path_buf();
+        };
+        let parent = requested.parent().unwrap_or_else(|| Path::new(""));
+        for discriminator in 2usize.. {
+            let candidate = parent
+                .join(format!("__dexdec_case_conflict_{discriminator}"))
+                .join(file_name);
+            if self.portable.insert(Self::portable_key(&candidate)) {
+                self.exact
+                    .insert(requested.to_path_buf(), candidate.clone());
+                return candidate;
+            }
+        }
+        unreachable!("unbounded output path discriminator");
+    }
+
+    fn portable_key(path: &Path) -> String {
+        path.components()
+            .map(|component| component.as_os_str().to_string_lossy().to_lowercase())
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+}
+
 struct SelectionResolver<'a> {
     catalog: &'a crate::ArchiveCatalog,
 }
@@ -343,5 +386,31 @@ impl ClassFile {
             )));
         }
         Ok(selectors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SourceOutputPaths;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn case_insensitive_source_paths_do_not_overwrite_each_other() {
+        let mut paths = SourceOutputPaths::default();
+        let upper = paths.claim(Path::new("example/C.java"));
+        let duplicate = paths.claim(Path::new("example/C.java"));
+        let lower = paths.claim(Path::new("example/c.java"));
+
+        assert_eq!(upper, PathBuf::from("example/C.java"));
+        assert_eq!(duplicate, upper);
+        assert_eq!(lower.file_name().unwrap(), "c.java");
+        assert_eq!(
+            lower,
+            PathBuf::from("example/__dexdec_case_conflict_2/c.java")
+        );
+        assert_ne!(
+            SourceOutputPaths::portable_key(&upper),
+            SourceOutputPaths::portable_key(&lower)
+        );
     }
 }

--- a/dexdec/src/ir/analysis/termination.rs
+++ b/dexdec/src/ir/analysis/termination.rs
@@ -80,7 +80,9 @@ impl MethodTermination {
 
     fn is_no_return_call(&self, instruction: &InsnNode) -> bool {
         self.exact_internal_target(instruction)
-            .is_some_and(|target| self.no_return.contains(target))
+            .is_some_and(|target| {
+                self.no_return.contains(target) && !preserves_source_continuation(target)
+            })
     }
 
     fn exact_internal_target<'a>(
@@ -160,8 +162,22 @@ impl<'a> ReturnReachability<'a> {
         let Some(MemberReference::Method(target)) = instruction.payload.reference.as_ref() else {
             return false;
         };
-        self.members.contains(target) && !self.may_return.contains(target)
+        self.members.contains(target)
+            && !self.may_return.contains(target)
+            && !preserves_source_continuation(target)
     }
+}
+
+/// Kotlin emits these calls as compiler markers around code that is expected
+/// to be inlined. Their runtime implementations deliberately throw, but the
+/// bytecode following the marker is still the source-level continuation that
+/// a decompiler must preserve.
+fn preserves_source_continuation(target: &MethodReference) -> bool {
+    target.owner.as_object() == Some("kotlin/jvm/internal/Intrinsics")
+        && matches!(
+            target.name.as_str(),
+            "reifiedOperationMarker" | "needClassReification"
+        )
 }
 
 #[cfg(test)]
@@ -258,5 +274,57 @@ mod tests {
         let summary = MethodTermination::analyze([&left, &right]);
         assert!(summary.apply(&mut left));
         assert!(summary.apply(&mut right));
+    }
+
+    #[test]
+    fn kotlin_reification_markers_preserve_source_continuation() {
+        let marker = MethodReference {
+            owner: ArgType::object("kotlin/jvm/internal/Intrinsics"),
+            name: "reifiedOperationMarker".to_string(),
+            descriptor: MethodDescriptor {
+                parameters: vec![ArgType::INT, ArgType::object("java/lang/String")],
+                return_type: ArgType::VOID,
+            },
+        };
+        assert!(preserves_source_continuation(&marker));
+        let mut class_reification = marker.clone();
+        class_reification.name = "needClassReification".to_string();
+        assert!(preserves_source_continuation(&class_reification));
+        let mut explicit_throw = marker.clone();
+        explicit_throw.name = "throwUndefinedForReified".to_string();
+        assert!(!preserves_source_continuation(&explicit_throw));
+
+        let mut marker_body = CFG::with_method(MethodContext::new(
+            marker.owner.clone(),
+            marker.name.clone(),
+            marker.descriptor.clone(),
+            true,
+        ));
+        let mut marker_entry = Block::new(0);
+        marker_entry.push(InsnNode::throw(crate::ir::InsnArg::lit(
+            0,
+            ArgType::object("java/lang/Throwable"),
+        )));
+        marker_body.add_block(marker_entry);
+
+        let mut caller = graph("caller");
+        let mut entry = Block::new(0);
+        let mut invoke = InsnNode::invoke(InvokeType::Static, 0, Vec::new());
+        invoke.payload.reference = Some(MemberReference::Method(marker));
+        entry.push(invoke);
+        entry.push(InsnNode::goto(1));
+        caller.add_block(entry);
+        let mut normal = Block::new(1);
+        normal.push(InsnNode::return_void());
+        caller.add_block(normal);
+        caller.add_edge(BlockId::new(0), BlockId::new(1), EdgeKind::Normal);
+
+        let summary = MethodTermination::analyze([&marker_body, &caller]);
+        assert!(!summary.apply(&mut caller));
+        assert_eq!(caller.block(BlockId::new(0)).expect("entry").insns.len(), 2);
+        assert_eq!(
+            caller.successors_with_kind(BlockId::new(0)),
+            &[(BlockId::new(1), EdgeKind::Normal)]
+        );
     }
 }

--- a/dexdec/src/ir/analysis/termination.rs
+++ b/dexdec/src/ir/analysis/termination.rs
@@ -7,7 +7,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::ir::{EdgeKind, InsnNode, InsnType, InvokeType, MemberReference, MethodReference, CFG};
+use crate::ir::{
+    ArgType, EdgeKind, InsnNode, InsnType, InvokeType, MemberReference, MethodReference, CFG,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct MethodTermination {
@@ -168,22 +170,26 @@ impl<'a> ReturnReachability<'a> {
     }
 }
 
-/// Kotlin emits these calls as compiler markers around code that is expected
-/// to be inlined. Their runtime implementations deliberately throw, but the
-/// bytecode following the marker is still the source-level continuation that
-/// a decompiler must preserve.
+/// Preserves bytecode continuations that still carry source-level meaning.
+///
+/// A non-void invocation can feed a `move-result` even when its implementation
+/// never returns at runtime. Removing that continuation loses the original
+/// expression or return value. Kotlin reification calls are void compiler
+/// markers with the same property: their throwing runtime implementations are
+/// placeholders for code expected to be inlined.
 fn preserves_source_continuation(target: &MethodReference) -> bool {
-    target.owner.as_object() == Some("kotlin/jvm/internal/Intrinsics")
-        && matches!(
-            target.name.as_str(),
-            "reifiedOperationMarker" | "needClassReification"
-        )
+    target.descriptor.return_type != ArgType::VOID
+        || (target.owner.as_object() == Some("kotlin/jvm/internal/Intrinsics")
+            && matches!(
+                target.name.as_str(),
+                "reifiedOperationMarker" | "needClassReification"
+            ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{ArgType, Block, BlockId, MethodContext, MethodDescriptor};
+    use crate::ir::{Block, BlockId, MethodContext, MethodDescriptor};
 
     fn reference(name: &str) -> MethodReference {
         MethodReference {
@@ -320,6 +326,50 @@ mod tests {
         caller.add_edge(BlockId::new(0), BlockId::new(1), EdgeKind::Normal);
 
         let summary = MethodTermination::analyze([&marker_body, &caller]);
+        assert!(!summary.apply(&mut caller));
+        assert_eq!(caller.block(BlockId::new(0)).expect("entry").insns.len(), 2);
+        assert_eq!(
+            caller.successors_with_kind(BlockId::new(0)),
+            &[(BlockId::new(1), EdgeKind::Normal)]
+        );
+    }
+
+    #[test]
+    fn non_void_no_return_call_preserves_result_continuation() {
+        let target = MethodReference {
+            owner: ArgType::object("example/Test"),
+            name: "failWithValue".to_string(),
+            descriptor: MethodDescriptor {
+                parameters: Vec::new(),
+                return_type: ArgType::object("java/lang/Object"),
+            },
+        };
+        let mut target_body = CFG::with_method(MethodContext::new(
+            target.owner.clone(),
+            target.name.clone(),
+            target.descriptor.clone(),
+            true,
+        ));
+        let mut target_entry = Block::new(0);
+        target_entry.push(InsnNode::throw(crate::ir::InsnArg::lit(
+            0,
+            ArgType::object("java/lang/Throwable"),
+        )));
+        target_body.add_block(target_entry);
+
+        let mut caller = graph("caller");
+        let mut entry = Block::new(0);
+        let mut invoke = InsnNode::invoke(InvokeType::Static, 0, Vec::new());
+        invoke.payload.reference = Some(MemberReference::Method(target));
+        entry.push(invoke);
+        entry.push(InsnNode::goto(1));
+        caller.add_block(entry);
+        let mut normal = Block::new(1);
+        normal.push(InsnNode::return_void());
+        caller.add_block(normal);
+        caller.add_edge(BlockId::new(0), BlockId::new(1), EdgeKind::Normal);
+
+        let summary = MethodTermination::analyze([&target_body, &caller]);
         assert!(!summary.apply(&mut caller));
         assert_eq!(caller.block(BlockId::new(0)).expect("entry").insns.len(), 2);
         assert_eq!(

--- a/dexdec/src/ir/semantic/normalize.rs
+++ b/dexdec/src/ir/semantic/normalize.rs
@@ -2,8 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ir::{
     analysis::{SsaValueGraph, SsaVar},
-    InsnArg, RegionGraph, SemanticExpression, SemanticFoldError, SemanticFolder, SemanticLabel,
-    SemanticLeaveKind, SemanticPredicate, SemanticVisitor,
+    InsnArg, LiteralArg, RegionGraph, SemanticExpression, SemanticExpressionTransform,
+    SemanticFoldError, SemanticFolder, SemanticInstructions, SemanticLabel, SemanticLeaveKind,
+    SemanticOperation, SemanticPredicate, SemanticStatement, SemanticVisitor,
 };
 
 use super::{
@@ -743,7 +744,7 @@ impl SemanticFolder for SourceSemanticNormalizer {
 }
 
 /// Remove a vacuous predicate when source-value recovery has transferred its
-/// evaluation into the immediately following condition.
+/// evaluation into the immediately following condition or value expression.
 ///
 /// The shared instruction identity is important: two bytecode comparisons
 /// that happen to look alike must still be emitted twice. We also require the
@@ -751,27 +752,70 @@ impl SemanticFolder for SourceSemanticNormalizer {
 /// deleting the stale evaluation cannot reorder throws or side effects.
 struct RedundantVacuousPredicate;
 
+struct OperationRegisterReplacement {
+    target: crate::ir::InstructionId,
+    result: crate::ir::RegisterArg,
+    replaced: bool,
+}
+
+impl SemanticExpressionTransform for OperationRegisterReplacement {
+    fn transform_operation(&mut self, operation: SemanticOperation) -> SemanticExpression {
+        if operation.id == self.target {
+            self.replaced = true;
+            SemanticExpression::Register(self.result.clone())
+        } else {
+            SemanticExpression::Operation(Box::new(operation))
+        }
+    }
+}
+
 impl RedundantVacuousPredicate {
     fn rewrite(node: SemanticNode) -> SemanticNode {
         let SemanticNode::Sequence(nodes) = node else {
             return node;
         };
-        let redundant = nodes
-            .windows(2)
-            .map(|pair| {
-                Self::vacuous_test_id(&pair[0])
-                    .is_some_and(|test| Self::node_replays_before_effects(&pair[1], test))
-            })
-            .chain(std::iter::once(false))
-            .collect::<Vec<_>>();
-        let retained = nodes
-            .into_iter()
-            .zip(redundant)
-            .filter_map(|(node, redundant)| (!redundant).then_some(node));
+        let mut retained = Vec::with_capacity(nodes.len());
+        let mut index = 0;
+        while index < nodes.len() {
+            let redundant = Self::vacuous_is_pure(&nodes[index])
+                || nodes
+                    .get(index + 1)
+                    .and_then(|following| {
+                        Self::vacuous_effectful_test_id(&nodes[index]).map(|test| (following, test))
+                    })
+                    .is_some_and(|(following, test)| {
+                        Self::node_replays_before_effects(following, test)
+                    });
+            if redundant {
+                index += 1;
+                continue;
+            }
+            if let Some(following) = nodes.get(index + 1) {
+                if let Some(materialized) = Self::materialize_vacuous(&nodes[index], following) {
+                    retained.push(materialized);
+                    index += 2;
+                    continue;
+                }
+            }
+            retained.push(nodes[index].clone());
+            index += 1;
+        }
         SemanticNode::sequence(retained)
     }
 
-    fn vacuous_test_id(node: &SemanticNode) -> Option<crate::ir::InstructionId> {
+    fn vacuous_is_pure(node: &SemanticNode) -> bool {
+        let SemanticNode::If {
+            condition,
+            then_node,
+            else_node: None,
+        } = node
+        else {
+            return false;
+        };
+        matches!(then_node.as_ref(), SemanticNode::Empty) && condition.effects().is_pure()
+    }
+
+    fn vacuous_effectful_test_id(node: &SemanticNode) -> Option<crate::ir::InstructionId> {
         let SemanticNode::If {
             condition,
             then_node,
@@ -783,7 +827,181 @@ impl RedundantVacuousPredicate {
         if !matches!(then_node.as_ref(), SemanticNode::Empty) {
             return None;
         }
-        Self::single_test_id(condition)
+        let mut ids = BTreeSet::new();
+        Self::collect_effectful_test_ids(condition, &mut ids);
+        (ids.len() == 1).then(|| ids.into_iter().next()).flatten()
+    }
+
+    fn materialize_vacuous(node: &SemanticNode, following: &SemanticNode) -> Option<SemanticNode> {
+        let test_id = Self::vacuous_effectful_test_id(node)?;
+        let condition = match node {
+            SemanticNode::If {
+                condition,
+                then_node,
+                else_node: None,
+            } if matches!(then_node.as_ref(), SemanticNode::Empty) => condition,
+            _ => return None,
+        };
+        let test = Self::find_test_operation(condition, test_id)?;
+        let target = Self::direct_replayed_operation(&test, following)?;
+        let result = target.result.clone()?;
+        if Self::operation_occurrences(following, target.id) == 0 {
+            return None;
+        }
+        let guard = Self::guard_for_test(condition, test_id)?;
+        let value = if matches!(guard, SemanticPredicate::True) {
+            SemanticExpression::Operation(Box::new(target.clone()))
+        } else {
+            let fallback = result
+                .ty
+                .is_known()
+                .then(|| LiteralArg::new(0, result.ty.clone()))?;
+            SemanticExpression::select(
+                guard,
+                SemanticExpression::Operation(Box::new(target.clone())),
+                SemanticExpression::Literal(fallback),
+            )
+        };
+        let definition = SemanticStatement::definition(target.id, result.clone(), value);
+        let SemanticNode::BasicBlock(block) = following.clone() else {
+            return None;
+        };
+        if block.statements.iter().any(|statement| {
+            statement
+                .instruction_ref()
+                .is_some_and(|operation| operation.id == target.id)
+        }) {
+            return None;
+        }
+        let mut block = SemanticNode::BasicBlock(block);
+        let mut replacement = OperationRegisterReplacement {
+            target: target.id,
+            result,
+            replaced: false,
+        };
+        SemanticInstructions::transform_node(&mut block, &mut replacement).ok()?;
+        replacement.replaced.then(|| {
+            let SemanticNode::BasicBlock(mut block) = block else {
+                unreachable!("materialized basic block changed shape");
+            };
+            block.statements.insert(0, definition);
+            SemanticNode::BasicBlock(block)
+        })
+    }
+
+    fn find_test_operation(
+        predicate: &SemanticPredicate,
+        target: crate::ir::InstructionId,
+    ) -> Option<SemanticOperation> {
+        match predicate {
+            SemanticPredicate::Test(operation) if operation.id == target => Some(operation.clone()),
+            SemanticPredicate::Not(inner) => Self::find_test_operation(inner, target),
+            SemanticPredicate::And(terms) | SemanticPredicate::Or(terms) => terms
+                .iter()
+                .find_map(|term| Self::find_test_operation(term, target)),
+            SemanticPredicate::Test(_) | SemanticPredicate::True | SemanticPredicate::False => None,
+        }
+    }
+
+    fn direct_replayed_operation(
+        test: &SemanticOperation,
+        following: &SemanticNode,
+    ) -> Option<SemanticOperation> {
+        let operands = test.evaluation_operands().ok()?;
+        let candidates = operands
+            .into_iter()
+            .filter_map(|operand| match operand {
+                SemanticExpression::Operation(operation)
+                    if operation.result.is_some()
+                        && operation.id.is_valid()
+                        && !operation.effects().without_control().is_pure()
+                        && Self::operation_occurrences(following, operation.id) != 0 =>
+                {
+                    Some(operation.as_ref().clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        (candidates.len() == 1)
+            .then(|| candidates.into_iter().next())
+            .flatten()
+    }
+
+    fn guard_for_test(
+        predicate: &SemanticPredicate,
+        target: crate::ir::InstructionId,
+    ) -> Option<SemanticPredicate> {
+        match predicate {
+            SemanticPredicate::Test(operation) if operation.id == target => {
+                Some(SemanticPredicate::True)
+            }
+            SemanticPredicate::Not(inner) => Self::guard_for_test(inner, target),
+            SemanticPredicate::And(terms) => {
+                for (index, term) in terms.iter().enumerate() {
+                    let direct = match term {
+                        SemanticPredicate::Test(operation) => operation.id == target,
+                        SemanticPredicate::Not(inner) => {
+                            matches!(inner.as_ref(), SemanticPredicate::Test(operation) if operation.id == target)
+                        }
+                        _ => false,
+                    };
+                    if !direct {
+                        continue;
+                    }
+                    if terms[..index]
+                        .iter()
+                        .any(|prefix| !prefix.effects().is_pure())
+                    {
+                        return None;
+                    }
+                    return Some(match &terms[..index] {
+                        [] => SemanticPredicate::True,
+                        [single] => single.clone(),
+                        prefix => SemanticPredicate::And(prefix.to_vec()),
+                    });
+                }
+                None
+            }
+            SemanticPredicate::Or(_) => None,
+            SemanticPredicate::Test(_) | SemanticPredicate::True | SemanticPredicate::False => None,
+        }
+    }
+
+    fn operation_occurrences(node: &SemanticNode, target: crate::ir::InstructionId) -> usize {
+        struct Counter {
+            target: crate::ir::InstructionId,
+            count: usize,
+        }
+        impl SemanticVisitor for Counter {
+            fn enter_operation(&mut self, operation: &SemanticOperation) {
+                if operation.id == self.target {
+                    self.count += 1;
+                }
+            }
+        }
+        let mut counter = Counter { target, count: 0 };
+        counter.visit_node(node);
+        counter.count
+    }
+
+    fn collect_effectful_test_ids(
+        predicate: &SemanticPredicate,
+        ids: &mut BTreeSet<crate::ir::InstructionId>,
+    ) {
+        match predicate {
+            SemanticPredicate::Test(operation) => {
+                if operation.id.is_valid() && !operation.effects().without_control().is_pure() {
+                    ids.insert(operation.id);
+                }
+            }
+            SemanticPredicate::Not(inner) => Self::collect_effectful_test_ids(inner, ids),
+            SemanticPredicate::And(terms) | SemanticPredicate::Or(terms) => {
+                terms
+                    .iter()
+                    .for_each(|term| Self::collect_effectful_test_ids(term, ids));
+            }
+            SemanticPredicate::True | SemanticPredicate::False => {}
+        }
     }
 
     fn single_test_id(predicate: &SemanticPredicate) -> Option<crate::ir::InstructionId> {
@@ -803,18 +1021,64 @@ impl RedundantVacuousPredicate {
             SemanticNode::If { condition, .. } => {
                 Self::predicate_replays_before_effects(condition, target)
             }
+            SemanticNode::BasicBlock(block) => {
+                for statement in &block.statements {
+                    if Self::statement_replays_before_effects(statement, target) {
+                        return true;
+                    }
+                    if !statement.effects().is_pure() {
+                        return false;
+                    }
+                }
+                false
+            }
+            SemanticNode::Leave(leave) => {
+                if let Some(condition) = &leave.condition {
+                    if Self::predicate_replays_before_effects(condition, target) {
+                        return true;
+                    }
+                    if !condition.effects().is_pure() {
+                        return false;
+                    }
+                }
+                leave
+                    .value()
+                    .is_some_and(|value| Self::expression_replays_before_effects(value, target))
+            }
             SemanticNode::Empty
             | SemanticNode::Sequence(_)
-            | SemanticNode::BasicBlock(_)
             | SemanticNode::Loop { .. }
             | SemanticNode::For { .. }
             | SemanticNode::ForEach { .. }
             | SemanticNode::Switch { .. }
             | SemanticNode::Try { .. }
             | SemanticNode::Synchronized { .. }
-            | SemanticNode::Label { .. }
-            | SemanticNode::Leave(_) => false,
+            | SemanticNode::Label { .. } => false,
         }
+    }
+
+    fn statement_replays_before_effects(
+        statement: &crate::ir::SemanticStatement,
+        target: crate::ir::InstructionId,
+    ) -> bool {
+        if let Some(value) = statement.value() {
+            return Self::expression_replays_before_effects(value, target);
+        }
+        let Some(instruction) = statement.instruction_ref() else {
+            return false;
+        };
+        let Ok(operands) = instruction.evaluation_operands() else {
+            return false;
+        };
+        for operand in operands {
+            if Self::expression_replays_before_effects(operand, target) {
+                return true;
+            }
+            if !operand.effects().is_pure() {
+                return false;
+            }
+        }
+        false
     }
 
     fn predicate_replays_before_effects(
@@ -840,9 +1104,17 @@ impl RedundantVacuousPredicate {
                 false
             }
             SemanticPredicate::Not(inner) => Self::predicate_replays_before_effects(inner, target),
-            SemanticPredicate::And(terms) | SemanticPredicate::Or(terms) => terms
-                .first()
-                .is_some_and(|term| Self::predicate_replays_before_effects(term, target)),
+            SemanticPredicate::And(terms) | SemanticPredicate::Or(terms) => {
+                for term in terms {
+                    if Self::predicate_replays_before_effects(term, target) {
+                        return true;
+                    }
+                    if !term.effects().is_pure() {
+                        return false;
+                    }
+                }
+                false
+            }
             SemanticPredicate::True | SemanticPredicate::False => false,
         }
     }
@@ -1677,8 +1949,9 @@ impl SemanticVisitor for SemanticSize {
 mod redundant_vacuous_predicate_tests {
     use super::*;
     use crate::ir::{
-        ArgType, IfOp, InsnNode, InsnType, InstructionId, InvokeType, LiteralArg, RegisterArg,
-        SemanticOperand, SemanticOperation,
+        ArgType, BlockId, IfOp, InsnNode, InsnType, InstructionId, InvokeType, LiteralArg,
+        RegionId, RegisterArg, SemanticBlock, SemanticLeave, SemanticLeaveKind, SemanticOperand,
+        SemanticOperation, SemanticStatement,
     };
 
     fn invoke_predicate(id: usize) -> SemanticPredicate {
@@ -1687,6 +1960,21 @@ mod redundant_vacuous_predicate_tests {
         instruction.payload.invoke_type = Some(InvokeType::Static);
         instruction.result = Some(RegisterArg::new_ssa(0, id as u32, ArgType::BOOLEAN));
         SemanticPredicate::Test(SemanticOperation::from_parts(instruction, Vec::new(), None))
+    }
+
+    fn pure_predicate(id: usize) -> SemanticPredicate {
+        let mut instruction = InsnNode::new(InsnType::If, 2);
+        instruction.id = InstructionId::new(id);
+        instruction.payload.if_op = Some(IfOp::Eq);
+        let left = RegisterArg::new_ssa(0, id as u32, ArgType::INT);
+        SemanticPredicate::Test(SemanticOperation::from_parts(
+            instruction,
+            vec![
+                SemanticExpression::Register(left),
+                SemanticExpression::Literal(LiteralArg::int(0)),
+            ],
+            None,
+        ))
     }
 
     fn replaying_predicate(
@@ -1717,6 +2005,92 @@ mod redundant_vacuous_predicate_tests {
         }
     }
 
+    fn replaying_block(id: usize, replayed: SemanticPredicate) -> SemanticNode {
+        let value = SemanticExpression::select(
+            replayed,
+            SemanticExpression::Literal(LiteralArg::int(0)),
+            SemanticExpression::Literal(LiteralArg::int(1)),
+        );
+        SemanticNode::BasicBlock(SemanticBlock {
+            id: BlockId::new(id as u32),
+            statements: vec![SemanticStatement::definition(
+                InstructionId::new(id),
+                RegisterArg::new_ssa(1, id as u32, ArgType::INT),
+                value,
+            )],
+        })
+    }
+
+    fn invoke_value(id: usize) -> SemanticOperation {
+        let mut instruction = InsnNode::new(InsnType::Invoke, 0);
+        instruction.id = InstructionId::new(id);
+        instruction.payload.invoke_type = Some(InvokeType::Static);
+        instruction.result = Some(RegisterArg::new_ssa(0, id as u32, ArgType::INT));
+        SemanticOperation::from_parts(instruction, Vec::new(), None)
+    }
+
+    fn value_test(id: usize, value: SemanticOperation) -> SemanticPredicate {
+        let mut instruction = InsnNode::new(InsnType::If, 2);
+        instruction.id = InstructionId::new(id);
+        instruction.payload.if_op = Some(IfOp::Le);
+        SemanticPredicate::Test(SemanticOperation::from_parts(
+            instruction,
+            vec![
+                SemanticExpression::Operation(Box::new(value)),
+                SemanticExpression::Literal(LiteralArg::int(0)),
+            ],
+            None,
+        ))
+    }
+
+    fn effectful_following_block(
+        id: usize,
+        predicate: SemanticPredicate,
+        prefix: SemanticOperation,
+    ) -> SemanticNode {
+        let selected = SemanticExpression::select(
+            predicate,
+            SemanticExpression::Literal(LiteralArg::int(0)),
+            SemanticExpression::Literal(LiteralArg::int(1)),
+        );
+        let mut instruction = InsnNode::new(InsnType::Invoke, 2);
+        instruction.id = InstructionId::new(id);
+        instruction.payload.invoke_type = Some(InvokeType::Static);
+        instruction.result = Some(RegisterArg::new_ssa(1, id as u32, ArgType::INT));
+        let value = SemanticExpression::Operation(Box::new(SemanticOperation::from_parts(
+            instruction,
+            vec![SemanticExpression::Operation(Box::new(prefix)), selected],
+            None,
+        )));
+        SemanticNode::BasicBlock(SemanticBlock {
+            id: BlockId::new(id as u32),
+            statements: vec![SemanticStatement::definition(
+                InstructionId::new(id),
+                RegisterArg::new_ssa(1, id as u32, ArgType::INT),
+                value,
+            )],
+        })
+    }
+
+    fn replaying_return(replayed: SemanticPredicate) -> SemanticNode {
+        let value = SemanticExpression::select(
+            replayed,
+            SemanticExpression::Literal(LiteralArg::int(0)),
+            SemanticExpression::Literal(LiteralArg::int(1)),
+        );
+        SemanticNode::Leave(SemanticLeave {
+            site: None,
+            condition: None,
+            kind: SemanticLeaveKind::Return(Some(value)),
+            edge: None,
+            origin: None,
+            source: RegionId::new(0),
+            destination: RegionId::new(0),
+            target: RegionId::new(0),
+            cleanup: Vec::new(),
+        })
+    }
+
     #[test]
     fn removes_vacuous_predicate_replayed_by_following_condition() {
         let predicate = invoke_predicate(1);
@@ -1736,6 +2110,139 @@ mod redundant_vacuous_predicate_tests {
     }
 
     #[test]
+    fn removes_vacuous_predicate_replayed_by_following_value() {
+        let predicate = invoke_predicate(1);
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate.clone()),
+            replaying_block(2, predicate),
+        ]));
+
+        assert!(
+            matches!(rewritten, SemanticNode::BasicBlock(block) if block.statements.len() == 1)
+        );
+    }
+
+    #[test]
+    fn materializes_shared_value_before_an_effectful_following_statement() {
+        let target = invoke_value(1);
+        let predicate = value_test(2, target.clone());
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate.clone()),
+            effectful_following_block(3, predicate, invoke_value(4)),
+        ]));
+
+        let SemanticNode::BasicBlock(block) = &rewritten else {
+            panic!("expected materialized following block, got {rewritten:?}");
+        };
+        assert_eq!(block.statements.len(), 2);
+        assert!(matches!(
+            &block.statements[0].kind,
+            crate::ir::SemanticStatementKind::Definition { id, value, .. }
+                if *id == target.id
+                    && matches!(value, SemanticExpression::Operation(operation) if operation.id == target.id)
+        ));
+        let remaining = SemanticNode::BasicBlock(SemanticBlock {
+            id: block.id,
+            statements: vec![block.statements[1].clone()],
+        });
+        assert_eq!(
+            RedundantVacuousPredicate::operation_occurrences(&remaining, target.id),
+            0
+        );
+    }
+
+    #[test]
+    fn materializes_shared_value_under_pure_short_circuit_guard() {
+        let target = invoke_value(1);
+        let predicate =
+            SemanticPredicate::And(vec![pure_predicate(2), value_test(3, target.clone())]);
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate.clone()),
+            effectful_following_block(4, predicate, invoke_value(5)),
+        ]));
+
+        let SemanticNode::BasicBlock(block) = &rewritten else {
+            panic!("expected materialized following block, got {rewritten:?}");
+        };
+        assert!(matches!(
+            &block.statements[0].kind,
+            crate::ir::SemanticStatementKind::Definition {
+                value: SemanticExpression::Select { condition, .. },
+                ..
+            } if matches!(condition, SemanticPredicate::Test(_))
+        ));
+    }
+
+    #[test]
+    fn removes_vacuous_composite_predicate_when_its_effectful_test_replays() {
+        let predicate = invoke_predicate(1);
+        let composite = SemanticPredicate::And(vec![pure_predicate(2), predicate.clone()]);
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(composite),
+            replaying_block(3, predicate),
+        ]));
+
+        assert!(
+            matches!(rewritten, SemanticNode::BasicBlock(block) if block.statements.len() == 1)
+        );
+    }
+
+    #[test]
+    fn removes_vacuous_predicate_replayed_in_later_short_circuit_term() {
+        let predicate = invoke_predicate(1);
+        let composite = SemanticPredicate::Or(vec![pure_predicate(2), predicate.clone()]);
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(composite),
+            replaying_block(3, predicate),
+        ]));
+
+        assert!(
+            matches!(rewritten, SemanticNode::BasicBlock(block) if block.statements.len() == 1)
+        );
+    }
+
+    #[test]
+    fn removes_vacuous_predicate_replayed_by_following_return_value() {
+        let predicate = invoke_predicate(1);
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate.clone()),
+            replaying_return(predicate),
+        ]));
+
+        assert!(matches!(
+            rewritten,
+            SemanticNode::Leave(SemanticLeave {
+                kind: SemanticLeaveKind::Return(Some(_)),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn keeps_vacuous_predicate_when_effect_precedes_value_replay() {
+        let predicate = invoke_predicate(1);
+        let mut following = replaying_block(2, predicate.clone());
+        let SemanticNode::BasicBlock(block) = &mut following else {
+            unreachable!();
+        };
+        let prefix = match invoke_predicate(3) {
+            SemanticPredicate::Test(operation) => SemanticStatement::definition(
+                InstructionId::new(3),
+                RegisterArg::new_ssa(2, 3, ArgType::BOOLEAN),
+                SemanticExpression::Operation(Box::new(operation)),
+            ),
+            _ => unreachable!(),
+        };
+        block.statements.insert(0, prefix);
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
+            vacuous(predicate),
+            following,
+        ]));
+
+        assert!(matches!(rewritten, SemanticNode::Sequence(nodes) if nodes.len() == 2));
+    }
+
+    #[test]
     fn keeps_vacuous_predicate_without_a_replay() {
         let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![
             vacuous(invoke_predicate(1)),
@@ -1743,6 +2250,15 @@ mod redundant_vacuous_predicate_tests {
         ]));
 
         assert!(matches!(rewritten, SemanticNode::Sequence(nodes) if nodes.len() == 2));
+    }
+
+    #[test]
+    fn removes_pure_vacuous_predicate_without_replay() {
+        let rewritten = RedundantVacuousPredicate::rewrite(SemanticNode::Sequence(vec![vacuous(
+            pure_predicate(1),
+        )]));
+
+        assert!(matches!(rewritten, SemanticNode::Empty));
     }
 
     #[test]

--- a/dexdec/src/language/java/dex.rs
+++ b/dexdec/src/language/java/dex.rs
@@ -2857,19 +2857,27 @@ impl DexJavaDialect {
             ..
         } = value
         {
+            let true_type = self.source_expression_type(when_true);
+            let false_type = self.source_expression_type(when_false);
+            let is_reference = |ty: &JavaType| !matches!(ty, JavaType::Primitive(_));
+            if when_false.literal_value() == Some(0) && true_type.as_ref().is_some_and(is_reference)
+            {
+                return true_type;
+            }
+            if when_true.literal_value() == Some(0) && false_type.as_ref().is_some_and(is_reference)
+            {
+                return false_type;
+            }
             let is_null = |branch: &SemanticExpression| {
                 branch.literal_value() == Some(0)
                     && branch.declared_type().is_some_and(ArgType::is_reference)
             };
             let joined = match (is_null(when_true), is_null(when_false)) {
-                (true, false) => self.source_expression_type(when_false),
-                (false, true) => self.source_expression_type(when_true),
-                _ => self
-                    .source_expression_type(when_true)
-                    .zip(self.source_expression_type(when_false))
-                    .and_then(|(left, right)| {
-                        self.type_relations().least_upper_bound(&left, &right)
-                    }),
+                (true, false) => false_type,
+                (false, true) => true_type,
+                _ => true_type.zip(false_type).and_then(|(left, right)| {
+                    self.type_relations().least_upper_bound(&left, &right)
+                }),
             };
             if joined.is_some() {
                 return joined;
@@ -4904,7 +4912,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::ir::analysis::SourceTypeEnvironment;
-    use crate::ir::{ArgType, RegisterArg};
+    use crate::ir::{ArgType, LiteralArg, RegisterArg, SemanticExpression, SemanticPredicate};
 
     use super::{DexJavaDialect, JavaDialect, JavaMemberNames, JavaType};
 
@@ -4962,6 +4970,34 @@ mod tests {
             JavaDialect::loop_variable(&mut dialect, &register).expect("reference source type");
 
         assert_eq!(ty, reference);
+    }
+
+    #[test]
+    fn select_types_an_integer_zero_as_null_against_a_reference_branch() {
+        let string = ArgType::string();
+        let source_string = JavaType::source_class("java.lang.String");
+        let dialect = DexJavaDialect::new(
+            true,
+            None,
+            &[],
+            &[],
+            &SourceTypeEnvironment::default(),
+            BTreeMap::from([(string.clone(), source_string.clone())]),
+            Arc::new(JavaMemberNames::default()),
+        )
+        .expect("static dialect");
+        let select = SemanticExpression::select(
+            SemanticPredicate::True,
+            SemanticExpression::Literal(LiteralArg::int(0)),
+            SemanticExpression::Register(RegisterArg {
+                reg_num: 1,
+                ty: string,
+                ssa_version: Some(1),
+                code_var: None,
+            }),
+        );
+
+        assert_eq!(dialect.source_expression_type(&select), Some(source_string));
     }
 }
 

--- a/dexdec/src/language/java/members.rs
+++ b/dexdec/src/language/java/members.rs
@@ -228,6 +228,28 @@ impl JavaMemberNames {
         self
     }
 
+    pub fn with_hidden_fields(mut self, fields: impl IntoIterator<Item = JavaFieldSymbol>) -> Self {
+        let mut scopes = BTreeMap::<ArgType, JavaNameScope>::new();
+        for (field, name) in &self.fields {
+            scopes
+                .entry(field.owner.clone())
+                .or_default()
+                .reserve(name.clone());
+        }
+        for field in fields.into_iter().collect::<BTreeSet<_>>() {
+            let key = field.key();
+            if self.fields.contains_key(&key) {
+                continue;
+            }
+            let name = scopes
+                .entry(field.owner.clone())
+                .or_default()
+                .claim(field.name.clone());
+            self.fields.insert(key, name);
+        }
+        self
+    }
+
     pub fn with_overloads(mut self, methods: impl IntoIterator<Item = MethodReference>) -> Self {
         for method in methods {
             self.overloads
@@ -365,6 +387,36 @@ impl FieldNameAllocation {
 
 struct MethodNameAllocation {
     scopes: BTreeMap<ArgType, JavaNameScope>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ir::ArgType;
+
+    use super::{JavaFieldSymbol, JavaIdentifier, JavaMemberNames};
+
+    #[test]
+    fn hidden_field_does_not_reuse_a_declared_field_name() {
+        let owner = ArgType::object("example/Owner");
+        let declared = JavaFieldSymbol::new(
+            owner.clone(),
+            JavaIdentifier::from_dex("value"),
+            ArgType::BOOLEAN,
+        );
+        let hidden = JavaFieldSymbol::new(
+            owner,
+            JavaIdentifier::from_dex("value"),
+            ArgType::object("example/Outer"),
+        );
+        let names =
+            JavaMemberNames::allocate([declared.clone()], []).with_hidden_fields([hidden.clone()]);
+
+        assert_eq!(
+            names.field_symbol(&declared),
+            JavaIdentifier::from_dex("value")
+        );
+        assert_ne!(names.field_symbol(&hidden), names.field_symbol(&declared));
+    }
 }
 
 impl MethodNameAllocation {

--- a/dexdec/src/language/java/mod.rs
+++ b/dexdec/src/language/java/mod.rs
@@ -29,6 +29,7 @@ pub use lower::{JavaDialect, JavaLowerer, JavaStructuralError};
 pub use members::{JavaConstructorLayout, JavaFieldSymbol, JavaMemberNames, JavaMethodSymbol};
 pub use normalize::{
     JavaAstNormalizer, JavaAstTransform, JavaInitializerExitLowering, JavaMethodCompletion,
+    JavaVoidTailLinearizer,
 };
 pub use rewrite::JavaAstRewriter;
 pub(crate) use source_types::GenericTypeProjection;

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -1,6 +1,6 @@
 use super::{
     JavaAssignOp, JavaAstRewriter, JavaBinaryOp, JavaCatch, JavaExpr, JavaIdentifier, JavaLiteral,
-    JavaMethodBody, JavaPrimitiveType, JavaStmt, JavaSwitchCase, JavaType,
+    JavaMethodBody, JavaPrimitiveType, JavaStmt, JavaSwitchCase, JavaType, JavaUnaryOp,
 };
 
 pub trait JavaAstTransform {
@@ -244,6 +244,7 @@ impl JavaAstNormalizer {
                 child => flattened.push(child),
             }
         }
+        changed |= ConditionalResultJoin::apply(&mut flattened);
         changed |= SwitchResultReturn::apply(&mut flattened);
         changed |= TerminalBranchLinearizer::apply(&mut flattened);
         (flattened, changed)
@@ -532,6 +533,227 @@ impl JavaAstNormalizer {
             JavaStmt::Synchronized { body, .. } => Self::strip_terminal_void_return(body),
             _ => false,
         }
+    }
+}
+
+/// Joins the two complementary uses of a synthetic boolean result.
+///
+/// Value recovery can spell a short-circuit branch as:
+/// `boolean c = false; if (a) { c = b; if (c) x; } if (!a || !c) y;`.
+/// When `a` is stable across the sequence, this is exactly
+/// `if (a && b) x; else y;`. Keeping the rewrite narrow is important because
+/// calls and field reads in `a` may intentionally be evaluated twice.
+struct ConditionalResultJoin;
+
+impl ConditionalResultJoin {
+    fn apply(statements: &mut Vec<JavaStmt>) -> bool {
+        let mut changed = false;
+        let mut index = 0usize;
+        while index + 2 < statements.len() {
+            let Some(replacement) = Self::candidate(&statements[index..index + 3]) else {
+                index += 1;
+                continue;
+            };
+            statements.splice(index..index + 3, std::iter::once(replacement));
+            changed = true;
+            index += 1;
+        }
+        changed
+    }
+
+    fn candidate(window: &[JavaStmt]) -> Option<JavaStmt> {
+        let [
+            JavaStmt::Variable {
+                ty: JavaType::Primitive(JavaPrimitiveType::Boolean),
+                name,
+                value: Some(JavaExpr::Literal(JavaLiteral::Boolean(false))),
+            },
+            JavaStmt::If {
+                condition: guard,
+                then_stmt: guarded,
+                else_stmt: None,
+            },
+            JavaStmt::If {
+                condition: complement,
+                then_stmt: fallback,
+                else_stmt: None,
+            },
+        ] = window
+        else {
+            return None;
+        };
+        let guarded = Self::statements(guarded)?;
+        let [
+            JavaStmt::Assign {
+                target: JavaExpr::Name(assigned),
+                op: JavaAssignOp::Assign,
+                value,
+            },
+            JavaStmt::If {
+                condition: JavaExpr::Name(tested),
+                then_stmt: success,
+                else_stmt: None,
+            },
+        ] = guarded
+        else {
+            return None;
+        };
+        if assigned != name
+            || tested != name
+            || !Self::is_complement(complement, guard, name)
+            || !Self::stable(guard)
+            || SwitchResultReturn::expression_uses(value, name)
+            || SwitchResultReturn::statement_uses(success, name)
+            || SwitchResultReturn::statement_uses(fallback, name)
+        {
+            return None;
+        }
+
+        let mut guard_names = std::collections::BTreeSet::new();
+        Self::collect_names(guard, &mut guard_names);
+        let mut writes = NameWriteDetector {
+            targets: &guard_names,
+            found: false,
+        };
+        writes.rewrite_expression(value.clone());
+        writes.rewrite_statement(success.as_ref().clone());
+        if writes.found {
+            return None;
+        }
+
+        Some(JavaStmt::If {
+            condition: JavaExpr::Binary {
+                left: Box::new(guard.clone()),
+                op: JavaBinaryOp::LogicalAnd,
+                right: Box::new(value.clone()),
+            },
+            then_stmt: Box::new(success.as_ref().clone()),
+            else_stmt: Some(Box::new(fallback.as_ref().clone())),
+        })
+    }
+
+    fn statements(statement: &JavaStmt) -> Option<&[JavaStmt]> {
+        match statement {
+            JavaStmt::Block(statements) => Some(statements),
+            _ => None,
+        }
+    }
+
+    fn is_complement(
+        expression: &JavaExpr,
+        guard: &JavaExpr,
+        result: &JavaIdentifier,
+    ) -> bool {
+        let JavaExpr::Binary {
+            left,
+            op: JavaBinaryOp::LogicalOr,
+            right,
+        } = expression
+        else {
+            return false;
+        };
+        let not_guard = guard.clone().negated();
+        (left.as_ref() == &not_guard && Self::is_negated_name(right, result))
+            || (right.as_ref() == &not_guard && Self::is_negated_name(left, result))
+    }
+
+    fn is_negated_name(expression: &JavaExpr, target: &JavaIdentifier) -> bool {
+        matches!(
+            expression,
+            JavaExpr::Unary {
+                op: JavaUnaryOp::LogicalNot,
+                operand,
+            } if matches!(operand.as_ref(), JavaExpr::Name(name) if name == target)
+        )
+    }
+
+    fn stable(expression: &JavaExpr) -> bool {
+        let mut pending = vec![expression];
+        while let Some(expression) = pending.pop() {
+            match expression {
+                JavaExpr::This
+                | JavaExpr::QualifiedThis(_)
+                | JavaExpr::Super
+                | JavaExpr::Name(_)
+                | JavaExpr::Literal(_)
+                | JavaExpr::ClassLiteral(_) => {}
+                JavaExpr::Unary { operand, .. }
+                | JavaExpr::Cast { value: operand, .. }
+                | JavaExpr::InstanceOf { value: operand, .. } => pending.push(operand),
+                JavaExpr::Binary { left, right, .. } => {
+                    pending.extend([left.as_ref(), right.as_ref()]);
+                }
+                JavaExpr::Conditional {
+                    condition,
+                    when_true,
+                    when_false,
+                } => pending.extend([
+                    condition.as_ref(),
+                    when_true.as_ref(),
+                    when_false.as_ref(),
+                ]),
+                JavaExpr::Field { .. }
+                | JavaExpr::StaticField { .. }
+                | JavaExpr::ArrayAccess { .. }
+                | JavaExpr::Call { .. }
+                | JavaExpr::MethodReference { .. }
+                | JavaExpr::Lambda { .. }
+                | JavaExpr::BlockLambda { .. }
+                | JavaExpr::New { .. }
+                | JavaExpr::NewArray { .. }
+                | JavaExpr::Update { .. }
+                | JavaExpr::Assignment { .. } => return false,
+            }
+        }
+        true
+    }
+
+    fn collect_names(expression: &JavaExpr, names: &mut std::collections::BTreeSet<JavaIdentifier>) {
+        struct Collector<'a>(&'a mut std::collections::BTreeSet<JavaIdentifier>);
+        impl JavaAstRewriter for Collector<'_> {
+            fn finish_expression(&mut self, expression: JavaExpr) -> JavaExpr {
+                if let JavaExpr::Name(name) = &expression {
+                    self.0.insert(name.clone());
+                }
+                expression
+            }
+        }
+        Collector(names).rewrite_expression(expression.clone());
+    }
+}
+
+struct NameWriteDetector<'a> {
+    targets: &'a std::collections::BTreeSet<JavaIdentifier>,
+    found: bool,
+}
+
+impl JavaAstRewriter for NameWriteDetector<'_> {
+    fn finish_expression(&mut self, expression: JavaExpr) -> JavaExpr {
+        let target = match &expression {
+            JavaExpr::Update { target, .. } | JavaExpr::Assignment { target, .. } => {
+                Some(target.as_ref())
+            }
+            _ => None,
+        };
+        if matches!(target, Some(JavaExpr::Name(name)) if self.targets.contains(name)) {
+            self.found = true;
+        }
+        expression
+    }
+
+    fn finish_statement(&mut self, statement: JavaStmt) -> JavaStmt {
+        let target = match &statement {
+            JavaStmt::Variable { name, .. } => Some(name),
+            JavaStmt::Assign {
+                target: JavaExpr::Name(name),
+                ..
+            } => Some(name),
+            _ => None,
+        };
+        if target.is_some_and(|name| self.targets.contains(name)) {
+            self.found = true;
+        }
+        statement
     }
 }
 
@@ -1344,6 +1566,127 @@ impl JavaAstRewriter for NameUseCounter<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn complementary_condition(guard: JavaExpr) -> JavaMethodBody {
+        let result = JavaIdentifier::from_dex("condition");
+        JavaMethodBody {
+            root: JavaStmt::Block(vec![
+                JavaStmt::Variable {
+                    ty: JavaType::boolean(),
+                    name: result.clone(),
+                    value: Some(JavaExpr::Literal(JavaLiteral::Boolean(false))),
+                },
+                JavaStmt::If {
+                    condition: guard.clone(),
+                    then_stmt: Box::new(JavaStmt::Block(vec![
+                        JavaStmt::Assign {
+                            target: JavaExpr::Name(result.clone()),
+                            op: JavaAssignOp::Assign,
+                            value: JavaExpr::Name(JavaIdentifier::from_dex("predicate")),
+                        },
+                        JavaStmt::If {
+                            condition: JavaExpr::Name(result.clone()),
+                            then_stmt: Box::new(JavaStmt::Expression(JavaExpr::Name(
+                                JavaIdentifier::from_dex("success"),
+                            ))),
+                            else_stmt: None,
+                        },
+                    ])),
+                    else_stmt: None,
+                },
+                JavaStmt::If {
+                    condition: JavaExpr::Binary {
+                        left: Box::new(guard.negated()),
+                        op: JavaBinaryOp::LogicalOr,
+                        right: Box::new(JavaExpr::Unary {
+                            op: JavaUnaryOp::LogicalNot,
+                            operand: Box::new(JavaExpr::Name(result)),
+                        }),
+                    },
+                    then_stmt: Box::new(JavaStmt::Expression(JavaExpr::Name(
+                        JavaIdentifier::from_dex("fallback"),
+                    ))),
+                    else_stmt: None,
+                },
+            ]),
+        }
+    }
+
+    #[test]
+    fn joins_complementary_boolean_result_branches() {
+        let guard = JavaExpr::Binary {
+            left: Box::new(JavaExpr::Name(JavaIdentifier::from_dex("flags"))),
+            op: JavaBinaryOp::Equal,
+            right: Box::new(JavaExpr::Literal(JavaLiteral::Integer(2))),
+        };
+        let mut body = complementary_condition(guard.clone());
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let [JavaStmt::If {
+            condition,
+            then_stmt,
+            else_stmt: Some(else_stmt),
+        }] = statements.as_slice()
+        else {
+            panic!("expected joined branch");
+        };
+        assert!(matches!(
+            condition,
+            JavaExpr::Binary {
+                left,
+                op: JavaBinaryOp::LogicalAnd,
+                right,
+            } if left.as_ref() == &guard
+                && matches!(right.as_ref(), JavaExpr::Name(name) if name.as_str() == "predicate")
+        ));
+        assert!(matches!(then_stmt.as_ref(), JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "success"));
+        assert!(matches!(else_stmt.as_ref(), JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "fallback"));
+    }
+
+    #[test]
+    fn keeps_complementary_result_when_guard_may_have_effects() {
+        let mut body = complementary_condition(JavaExpr::Call {
+            receiver: None,
+            owner: None,
+            type_arguments: Vec::new(),
+            method: JavaIdentifier::from_dex("guard"),
+            args: Vec::new(),
+        });
+        let original = body.clone();
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
+    }
+
+    #[test]
+    fn keeps_complementary_result_when_success_rewrites_guard_input() {
+        let guard_name = JavaIdentifier::from_dex("guard");
+        let mut body = complementary_condition(JavaExpr::Name(guard_name.clone()));
+        let JavaStmt::Block(statements) = &mut body.root else {
+            unreachable!();
+        };
+        let JavaStmt::If { then_stmt, .. } = &mut statements[1] else {
+            unreachable!();
+        };
+        let JavaStmt::Block(guarded) = then_stmt.as_mut() else {
+            unreachable!();
+        };
+        let JavaStmt::If { then_stmt, .. } = &mut guarded[1] else {
+            unreachable!();
+        };
+        **then_stmt = JavaStmt::Assign {
+            target: JavaExpr::Name(guard_name),
+            op: JavaAssignOp::Assign,
+            value: JavaExpr::Literal(JavaLiteral::Boolean(false)),
+        };
+        let original = body.clone();
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
+    }
 
     fn result_switch(has_default: bool, initializer: Option<JavaExpr>) -> JavaMethodBody {
         let result = JavaIdentifier::from_dex("result");

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -87,6 +87,89 @@ impl JavaAstTransform for JavaInitializerExitLowering {
     }
 }
 
+/// Flattens a materially larger terminal branch in a void method by returning
+/// from the smaller branch first.
+#[derive(Debug, Default)]
+pub struct JavaVoidTailLinearizer;
+
+impl JavaAstTransform for JavaVoidTailLinearizer {
+    type Error = std::convert::Infallible;
+
+    fn apply(&mut self, body: &mut JavaMethodBody) -> Result<bool, Self::Error> {
+        let JavaStmt::Block(statements) = &mut body.root else {
+            return Ok(false);
+        };
+        let Some(JavaStmt::If {
+            condition,
+            then_stmt,
+            else_stmt: Some(else_stmt),
+        }) = statements.last()
+        else {
+            return Ok(false);
+        };
+
+        let then_cost = TerminalBranchLinearizer::statement_cost(then_stmt);
+        let else_cost = TerminalBranchLinearizer::statement_cost(else_stmt);
+        let then_terminal = !TerminalBranchLinearizer::can_complete_normally(then_stmt);
+        let else_terminal = !TerminalBranchLinearizer::can_complete_normally(else_stmt);
+        let materially_unbalanced = then_cost.max(else_cost)
+            >= then_cost
+                .min(else_cost)
+                .saturating_add(TerminalBranchLinearizer::NESTING_PENALTY);
+        if !then_terminal && !else_terminal && !materially_unbalanced {
+            return Ok(false);
+        }
+
+        let condition = condition.clone();
+        let choose_then = if then_terminal != else_terminal {
+            then_terminal
+        } else {
+            then_cost <= else_cost
+        };
+        let Some(JavaStmt::If {
+            then_stmt,
+            else_stmt: Some(else_stmt),
+            ..
+        }) = statements.pop()
+        else {
+            unreachable!("void tail candidate changed before rewrite");
+        };
+        let (condition, early, trailing) = if choose_then {
+            (condition, *then_stmt, *else_stmt)
+        } else {
+            (condition.negated(), *else_stmt, *then_stmt)
+        };
+        let early = Self::with_return(early);
+        statements.push(JavaStmt::If {
+            condition,
+            then_stmt: Box::new(early),
+            else_stmt: None,
+        });
+        match trailing {
+            JavaStmt::Block(trailing) => statements.extend(trailing),
+            JavaStmt::Empty => {}
+            statement => statements.push(statement),
+        }
+        Ok(true)
+    }
+}
+
+impl JavaVoidTailLinearizer {
+    fn with_return(statement: JavaStmt) -> JavaStmt {
+        if !TerminalBranchLinearizer::can_complete_normally(&statement) {
+            return statement;
+        }
+        match statement {
+            JavaStmt::Block(mut statements) => {
+                statements.push(JavaStmt::Return(None));
+                JavaStmt::Block(statements)
+            }
+            JavaStmt::Empty => JavaStmt::Block(vec![JavaStmt::Return(None)]),
+            statement => JavaStmt::Block(vec![statement, JavaStmt::Return(None)]),
+        }
+    }
+}
+
 impl JavaAstNormalizer {
     fn normalize(root: JavaStmt) -> Result<(JavaStmt, bool), super::JavaStructuralError> {
         let mut pending = vec![SyntaxTask::Visit(root)];
@@ -1566,6 +1649,109 @@ impl JavaAstRewriter for NameUseCounter<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn marker(name: &str) -> JavaStmt {
+        JavaStmt::Expression(JavaExpr::Name(JavaIdentifier::from_dex(name)))
+    }
+
+    #[test]
+    fn void_tail_returns_from_small_then_branch() {
+        let condition = JavaExpr::Name(JavaIdentifier::from_dex("skip"));
+        let trailing = (0..8)
+            .map(|index| marker(&format!("work{index}")))
+            .collect::<Vec<_>>();
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::If {
+                condition: condition.clone(),
+                then_stmt: Box::new(JavaStmt::Block(vec![marker("skipWork")])),
+                else_stmt: Some(Box::new(JavaStmt::Block(trailing.clone()))),
+            }]),
+        };
+
+        assert!(JavaVoidTailLinearizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let JavaStmt::If {
+            condition: actual,
+            then_stmt,
+            else_stmt: None,
+        } = &statements[0]
+        else {
+            panic!("expected guard return");
+        };
+        assert_eq!(actual, &condition);
+        assert!(matches!(
+            then_stmt.as_ref(),
+            JavaStmt::Block(branch) if matches!(branch.last(), Some(JavaStmt::Return(None)))
+        ));
+        assert_eq!(&statements[1..], trailing.as_slice());
+    }
+
+    #[test]
+    fn void_tail_inverts_condition_for_small_else_branch() {
+        let condition = JavaExpr::Name(JavaIdentifier::from_dex("ready"));
+        let trailing = (0..8)
+            .map(|index| marker(&format!("work{index}")))
+            .collect::<Vec<_>>();
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::If {
+                condition: condition.clone(),
+                then_stmt: Box::new(JavaStmt::Block(trailing.clone())),
+                else_stmt: Some(Box::new(JavaStmt::Block(vec![marker("fallback")]))),
+            }]),
+        };
+
+        assert!(JavaVoidTailLinearizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        assert!(matches!(
+            &statements[0],
+            JavaStmt::If { condition: actual, else_stmt: None, .. }
+                if actual == &condition.clone().negated()
+        ));
+        assert_eq!(&statements[1..], trailing.as_slice());
+    }
+
+    #[test]
+    fn void_tail_keeps_balanced_if_else() {
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::If {
+                condition: JavaExpr::Name(JavaIdentifier::from_dex("condition")),
+                then_stmt: Box::new(marker("left")),
+                else_stmt: Some(Box::new(marker("right"))),
+            }]),
+        };
+        let original = body.clone();
+
+        assert!(!JavaVoidTailLinearizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
+    }
+
+    #[test]
+    fn void_tail_does_not_duplicate_existing_return() {
+        let trailing = (0..8)
+            .map(|index| marker(&format!("work{index}")))
+            .collect::<Vec<_>>();
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::If {
+                condition: JavaExpr::Name(JavaIdentifier::from_dex("done")),
+                then_stmt: Box::new(JavaStmt::Return(None)),
+                else_stmt: Some(Box::new(JavaStmt::Block(trailing))),
+            }]),
+        };
+
+        assert!(JavaVoidTailLinearizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        assert!(matches!(
+            &statements[0],
+            JavaStmt::If { then_stmt, else_stmt: None, .. }
+                if matches!(then_stmt.as_ref(), JavaStmt::Return(None))
+        ));
+    }
 
     fn complementary_condition(guard: JavaExpr) -> JavaMethodBody {
         let result = JavaIdentifier::from_dex("condition");

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -327,6 +327,7 @@ impl JavaAstNormalizer {
                 child => flattened.push(child),
             }
         }
+        changed |= StringSwitchRecovery::apply(&mut flattened);
         changed |= ConditionalResultJoin::apply(&mut flattened);
         changed |= SwitchResultReturn::apply(&mut flattened);
         changed |= TerminalBranchLinearizer::apply(&mut flattened);
@@ -837,6 +838,265 @@ impl JavaAstRewriter for NameWriteDetector<'_> {
             self.found = true;
         }
         statement
+    }
+}
+
+/// Reconstructs the two-switch lowering used for Java string switches.
+///
+/// `javac`/D8 first switches on `value.hashCode()`, stores a synthetic integer
+/// selector after an `equals` check, and then switches on that selector.  The
+/// source form is both shorter and single-evaluates the string selector.  This
+/// recovery accepts only the canonical one-string-per-hash shape and verifies
+/// every hash and fallback assignment before removing the synthetic local.
+struct StringSwitchRecovery;
+
+impl StringSwitchRecovery {
+    fn apply(statements: &mut Vec<JavaStmt>) -> bool {
+        let mut changed = false;
+        let mut index = 0usize;
+        while index + 2 < statements.len() {
+            let Some((synthetic, replacement)) =
+                Self::candidate(&statements[index..index + 3])
+            else {
+                index += 1;
+                continue;
+            };
+            let used_outside = statements[..index]
+                .iter()
+                .chain(&statements[index + 3..])
+                .any(|statement| SwitchResultReturn::statement_uses(statement, &synthetic));
+            if used_outside {
+                index += 1;
+                continue;
+            }
+            statements.splice(index..index + 3, std::iter::once(replacement));
+            changed = true;
+            index += 1;
+        }
+        changed
+    }
+
+    fn candidate(window: &[JavaStmt]) -> Option<(JavaIdentifier, JavaStmt)> {
+        let [
+            JavaStmt::Variable {
+                ty: JavaType::Primitive(JavaPrimitiveType::Int),
+                name: synthetic,
+                value: Some(JavaExpr::Literal(JavaLiteral::Integer(initial))),
+            },
+            JavaStmt::Switch {
+                label: None,
+                selector: hash_selector,
+                cases: hash_cases,
+            },
+            JavaStmt::Switch {
+                label: None,
+                selector: JavaExpr::Name(action_selector),
+                cases: action_cases,
+            },
+        ] = window
+        else {
+            return None;
+        };
+        if action_selector != synthetic {
+            return None;
+        }
+        let source = Self::hash_receiver(hash_selector)?;
+        if hash_cases.iter().filter(|case| case.is_default).count() != 1 {
+            return None;
+        }
+        let default_case = hash_cases.iter().find(|case| case.is_default)?;
+        if !default_case.labels.is_empty() {
+            return None;
+        }
+        let fallback = Self::fallback_selector(&default_case.body, synthetic)?;
+
+        let mut mappings = Vec::new();
+        for case in hash_cases.iter().filter(|case| !case.is_default) {
+            let [JavaExpr::Literal(JavaLiteral::Integer(hash))] = case.labels.as_slice() else {
+                return None;
+            };
+            let (literal, selected, rejected) =
+                Self::hash_case(&case.body, synthetic, source, *initial)?;
+            if rejected != fallback
+                || Self::string_hash(literal.as_utf16()) != *hash
+                || selected == fallback
+                || mappings
+                    .iter()
+                    .any(|(existing, _): &(i32, JavaLiteral)| existing == &selected)
+            {
+                return None;
+            }
+            mappings.push((selected, JavaLiteral::String(literal.clone())));
+        }
+        if mappings.is_empty() {
+            return None;
+        }
+
+        let mut recovered_cases = Vec::with_capacity(action_cases.len());
+        for case in action_cases {
+            if case
+                .body
+                .iter()
+                .any(|statement| SwitchResultReturn::statement_uses(statement, synthetic))
+            {
+                return None;
+            }
+            if case.is_default {
+                if !case.labels.is_empty() {
+                    return None;
+                }
+                recovered_cases.push(case.clone());
+                continue;
+            }
+            let mut labels = Vec::new();
+            for label in &case.labels {
+                let JavaExpr::Literal(JavaLiteral::Integer(selected)) = label else {
+                    return None;
+                };
+                let Some((_, literal)) = mappings
+                    .iter()
+                    .find(|(candidate, _)| candidate == selected)
+                else {
+                    return None;
+                };
+                labels.push(JavaExpr::Literal(literal.clone()));
+            }
+            if labels.is_empty() {
+                return None;
+            }
+            recovered_cases.push(JavaSwitchCase {
+                labels,
+                body: case.body.clone(),
+                is_default: false,
+            });
+        }
+
+        Some((
+            synthetic.clone(),
+            JavaStmt::Switch {
+                label: None,
+                selector: JavaExpr::Name(source.clone()),
+                cases: recovered_cases,
+            },
+        ))
+    }
+
+    fn hash_receiver(selector: &JavaExpr) -> Option<&JavaIdentifier> {
+        let JavaExpr::Call {
+            receiver: Some(receiver),
+            owner: None,
+            type_arguments,
+            method,
+            args,
+        } = selector
+        else {
+            return None;
+        };
+        if !type_arguments.is_empty() || method.as_str() != "hashCode" || !args.is_empty() {
+            return None;
+        }
+        let JavaExpr::Name(source) = receiver.as_ref() else {
+            return None;
+        };
+        Some(source)
+    }
+
+    fn hash_case<'a>(
+        body: &'a [JavaStmt],
+        synthetic: &JavaIdentifier,
+        source: &JavaIdentifier,
+        initial: i32,
+    ) -> Option<(&'a crate::ir::Utf16String, i32, i32)> {
+        let [
+            JavaStmt::If {
+                condition,
+                then_stmt,
+                else_stmt: None,
+            },
+            JavaStmt::Assign {
+                target: JavaExpr::Name(rejected_target),
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Literal(JavaLiteral::Integer(rejected)),
+            },
+            JavaStmt::Break(None),
+        ] = body
+        else {
+            return None;
+        };
+        if rejected_target != synthetic {
+            return None;
+        }
+        let literal = Self::equals_literal(condition, source)?;
+        let selected = Self::selected_value(then_stmt, synthetic, initial)?;
+        Some((literal, selected, *rejected))
+    }
+
+    fn equals_literal<'a>(
+        condition: &'a JavaExpr,
+        source: &JavaIdentifier,
+    ) -> Option<&'a crate::ir::Utf16String> {
+        let JavaExpr::Call {
+            receiver: Some(receiver),
+            owner: None,
+            type_arguments,
+            method,
+            args,
+        } = condition
+        else {
+            return None;
+        };
+        let [JavaExpr::Literal(JavaLiteral::String(literal))] = args.as_slice() else {
+            return None;
+        };
+        (type_arguments.is_empty()
+            && method.as_str() == "equals"
+            && matches!(receiver.as_ref(), JavaExpr::Name(candidate) if candidate == source))
+        .then_some(literal)
+    }
+
+    fn selected_value(
+        statement: &JavaStmt,
+        synthetic: &JavaIdentifier,
+        initial: i32,
+    ) -> Option<i32> {
+        let statements = match statement {
+            JavaStmt::Block(statements) => statements.as_slice(),
+            JavaStmt::Break(None) => return Some(initial),
+            _ => return None,
+        };
+        match statements {
+            [JavaStmt::Break(None)] => Some(initial),
+            [
+                JavaStmt::Assign {
+                    target: JavaExpr::Name(target),
+                    op: JavaAssignOp::Assign,
+                    value: JavaExpr::Literal(JavaLiteral::Integer(value)),
+                },
+                JavaStmt::Break(None),
+            ] if target == synthetic => Some(*value),
+            _ => None,
+        }
+    }
+
+    fn fallback_selector(body: &[JavaStmt], synthetic: &JavaIdentifier) -> Option<i32> {
+        let [
+            JavaStmt::Assign {
+                target: JavaExpr::Name(target),
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Literal(JavaLiteral::Integer(value)),
+            },
+            JavaStmt::Break(None),
+        ] = body
+        else {
+            return None;
+        };
+        (target == synthetic).then_some(*value)
+    }
+
+    fn string_hash(units: &[u16]) -> i32 {
+        units.iter().fold(0i32, |hash, unit| {
+            hash.wrapping_mul(31).wrapping_add(i32::from(*unit))
+        })
     }
 }
 
@@ -1872,6 +2132,169 @@ mod tests {
 
         assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
         assert_eq!(body.root, original.root);
+    }
+
+    fn assign_integer(name: &JavaIdentifier, value: i32) -> JavaStmt {
+        JavaStmt::Assign {
+            target: JavaExpr::Name(name.clone()),
+            op: JavaAssignOp::Assign,
+            value: JavaExpr::Literal(JavaLiteral::Integer(value)),
+        }
+    }
+
+    fn string_call(receiver: &JavaIdentifier, method: &str, args: Vec<JavaExpr>) -> JavaExpr {
+        JavaExpr::Call {
+            receiver: Some(Box::new(JavaExpr::Name(receiver.clone()))),
+            owner: None,
+            type_arguments: Vec::new(),
+            method: JavaIdentifier::from_dex(method),
+            args,
+        }
+    }
+
+    fn lowered_string_switch() -> JavaMethodBody {
+        let source = JavaIdentifier::from_dex("source");
+        let synthetic = JavaIdentifier::from_dex("selector");
+        let hash_case = |literal: &str, selected: i32| JavaSwitchCase {
+            labels: vec![JavaExpr::Literal(JavaLiteral::Integer(
+                StringSwitchRecovery::string_hash(
+                    &literal.encode_utf16().collect::<Vec<_>>(),
+                ),
+            ))],
+            body: vec![
+                JavaStmt::If {
+                    condition: string_call(
+                        &source,
+                        "equals",
+                        vec![JavaExpr::Literal(JavaLiteral::String(literal.into()))],
+                    ),
+                    then_stmt: Box::new(JavaStmt::Block(if selected == 0 {
+                        vec![JavaStmt::Break(None)]
+                    } else {
+                        vec![assign_integer(&synthetic, selected), JavaStmt::Break(None)]
+                    })),
+                    else_stmt: None,
+                },
+                assign_integer(&synthetic, -1),
+                JavaStmt::Break(None),
+            ],
+            is_default: false,
+        };
+        JavaMethodBody {
+            root: JavaStmt::Block(vec![
+                JavaStmt::Variable {
+                    ty: JavaType::Primitive(JavaPrimitiveType::Int),
+                    name: synthetic.clone(),
+                    value: Some(JavaExpr::Literal(JavaLiteral::Integer(0))),
+                },
+                JavaStmt::Switch {
+                    label: None,
+                    selector: string_call(&source, "hashCode", Vec::new()),
+                    cases: vec![
+                        hash_case("alpha", 0),
+                        hash_case("beta", 1),
+                        JavaSwitchCase {
+                            labels: Vec::new(),
+                            body: vec![
+                                assign_integer(&synthetic, -1),
+                                JavaStmt::Break(None),
+                            ],
+                            is_default: true,
+                        },
+                    ],
+                },
+                JavaStmt::Switch {
+                    label: None,
+                    selector: JavaExpr::Name(synthetic),
+                    cases: vec![
+                        JavaSwitchCase {
+                            labels: vec![JavaExpr::Literal(JavaLiteral::Integer(0))],
+                            body: vec![marker("first"), JavaStmt::Break(None)],
+                            is_default: false,
+                        },
+                        JavaSwitchCase {
+                            labels: vec![JavaExpr::Literal(JavaLiteral::Integer(1))],
+                            body: vec![marker("second"), JavaStmt::Break(None)],
+                            is_default: false,
+                        },
+                        JavaSwitchCase {
+                            labels: Vec::new(),
+                            body: vec![marker("fallback"), JavaStmt::Break(None)],
+                            is_default: true,
+                        },
+                    ],
+                },
+            ]),
+        }
+    }
+
+    #[test]
+    fn reconstructs_verified_string_switch() {
+        let mut body = lowered_string_switch();
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let [JavaStmt::Switch {
+            selector: JavaExpr::Name(source),
+            cases,
+            ..
+        }] = statements.as_slice()
+        else {
+            panic!("expected recovered string switch");
+        };
+        assert_eq!(source.as_str(), "source");
+        assert!(matches!(
+            cases[0].labels.as_slice(),
+            [JavaExpr::Literal(JavaLiteral::String(value))] if value.to_string_lossy() == "alpha"
+        ));
+        assert!(matches!(
+            cases[1].labels.as_slice(),
+            [JavaExpr::Literal(JavaLiteral::String(value))] if value.to_string_lossy() == "beta"
+        ));
+        assert!(cases[2].is_default);
+    }
+
+    #[test]
+    fn keeps_string_switch_lowering_when_hash_is_not_verified() {
+        let mut body = lowered_string_switch();
+        let JavaStmt::Block(statements) = &mut body.root else {
+            unreachable!();
+        };
+        let JavaStmt::Switch { cases, .. } = &mut statements[1] else {
+            unreachable!();
+        };
+        cases[0].labels[0] = JavaExpr::Literal(JavaLiteral::Integer(0));
+
+        JavaAstNormalizer.apply(&mut body).unwrap();
+        let JavaStmt::Block(statements) = &body.root else {
+            unreachable!();
+        };
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| matches!(statement, JavaStmt::Switch { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn keeps_string_switch_selector_when_used_after_dispatch() {
+        let mut body = lowered_string_switch();
+        let JavaStmt::Block(statements) = &mut body.root else {
+            unreachable!();
+        };
+        statements.push(JavaStmt::Expression(JavaExpr::Name(
+            JavaIdentifier::from_dex("selector"),
+        )));
+
+        JavaAstNormalizer.apply(&mut body).unwrap();
+        let JavaStmt::Block(statements) = &body.root else {
+            unreachable!();
+        };
+        assert!(matches!(statements.first(), Some(JavaStmt::Variable { .. })));
     }
 
     fn result_switch(has_default: bool, initializer: Option<JavaExpr>) -> JavaMethodBody {

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -1691,8 +1691,11 @@ impl JavaAstTransform for JavaAstNormalizer {
     type Error = super::JavaStructuralError;
 
     fn apply(&mut self, body: &mut JavaMethodBody) -> Result<bool, Self::Error> {
-        let (mut root, mut changed) =
+        let (root, mut changed) =
             Self::normalize(std::mem::replace(&mut body.root, JavaStmt::Empty))?;
+        let mut conditional_simplifier = ConditionalExpressionSimplifier::default();
+        let mut root = conditional_simplifier.rewrite_statement(root);
+        changed |= conditional_simplifier.changed;
         if let JavaStmt::Block(statements) = &mut root {
             if let Some(last) = statements.last_mut() {
                 changed |= Self::strip_terminal_void_return(last);
@@ -1703,6 +1706,52 @@ impl JavaAstTransform for JavaAstNormalizer {
         }
         body.root = root;
         Ok(changed)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ConditionalExpressionSimplifier {
+    changed: bool,
+}
+
+impl JavaAstRewriter for ConditionalExpressionSimplifier {
+    fn finish_expression(&mut self, expression: JavaExpr) -> JavaExpr {
+        let JavaExpr::Conditional {
+            condition,
+            when_true,
+            when_false,
+        } = expression
+        else {
+            return expression;
+        };
+        let JavaExpr::Conditional {
+            condition: nested_condition,
+            when_true: nested_true,
+            when_false: nested_false,
+        } = when_false.as_ref()
+        else {
+            return JavaExpr::Conditional {
+                condition,
+                when_true,
+                when_false,
+            };
+        };
+        if condition.as_ref() != nested_condition.as_ref()
+            || when_true.as_ref() != nested_true.as_ref()
+            || !ConditionalResultJoin::stable(condition.as_ref())
+        {
+            return JavaExpr::Conditional {
+                condition,
+                when_true,
+                when_false,
+            };
+        }
+        self.changed = true;
+        JavaExpr::Conditional {
+            condition,
+            when_true,
+            when_false: nested_false.clone(),
+        }
     }
 }
 
@@ -1912,6 +1961,71 @@ mod tests {
 
     fn marker(name: &str) -> JavaStmt {
         JavaStmt::Expression(JavaExpr::Name(JavaIdentifier::from_dex(name)))
+    }
+
+    fn repeated_conditional(condition: JavaExpr) -> JavaExpr {
+        JavaExpr::Conditional {
+            condition: Box::new(condition.clone()),
+            when_true: Box::new(JavaExpr::Literal(JavaLiteral::Integer(1))),
+            when_false: Box::new(JavaExpr::Conditional {
+                condition: Box::new(condition),
+                when_true: Box::new(JavaExpr::Literal(JavaLiteral::Integer(1))),
+                when_false: Box::new(JavaExpr::Literal(JavaLiteral::Integer(0))),
+            }),
+        }
+    }
+
+    #[test]
+    fn simplifies_repeated_stable_conditional_branch() {
+        let condition = JavaExpr::Name(JavaIdentifier::from_dex("enabled"));
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::Variable {
+                ty: JavaType::int(),
+                name: JavaIdentifier::from_dex("value"),
+                value: Some(repeated_conditional(condition.clone())),
+            }]),
+        };
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let JavaStmt::Variable { value: Some(value), .. } = &statements[0] else {
+            panic!("expected variable initializer");
+        };
+        assert_eq!(
+            value,
+            &JavaExpr::Conditional {
+                condition: Box::new(condition),
+                when_true: Box::new(JavaExpr::Literal(JavaLiteral::Integer(1))),
+                when_false: Box::new(JavaExpr::Literal(JavaLiteral::Integer(0))),
+            }
+        );
+    }
+
+    #[test]
+    fn keeps_repeated_effectful_conditional_branch() {
+        let condition = JavaExpr::Field {
+            owner: Box::new(JavaExpr::This),
+            name: JavaIdentifier::from_dex("enabled"),
+        };
+        let expression = repeated_conditional(condition);
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::Variable {
+                ty: JavaType::int(),
+                name: JavaIdentifier::from_dex("value"),
+                value: Some(expression.clone()),
+            }]),
+        };
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let JavaStmt::Variable { value: Some(value), .. } = &statements[0] else {
+            panic!("expected variable initializer");
+        };
+        assert_eq!(value, &expression);
     }
 
     #[test]

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -327,6 +327,18 @@ impl JavaAstNormalizer {
                 child => flattened.push(child),
             }
         }
+        let before = flattened.len();
+        flattened.retain(|statement| {
+            !matches!(
+                statement,
+                JavaStmt::If {
+                    condition,
+                    then_stmt,
+                    else_stmt: None,
+                } if Self::is_empty(then_stmt) && Self::pure_condition(condition)
+            )
+        });
+        changed |= flattened.len() != before;
         changed |= StringSwitchRecovery::apply(&mut flattened);
         changed |= ConditionalResultJoin::apply(&mut flattened);
         changed |= SwitchResultReturn::apply(&mut flattened);
@@ -599,6 +611,49 @@ impl JavaAstNormalizer {
             || matches!(statement, JavaStmt::Block(statements) if statements.is_empty())
     }
 
+    fn pure_condition(expression: &JavaExpr) -> bool {
+        match expression {
+            JavaExpr::This
+            | JavaExpr::QualifiedThis(_)
+            | JavaExpr::Super
+            | JavaExpr::Name(_)
+            | JavaExpr::Literal(_)
+            | JavaExpr::ClassLiteral(_) => true,
+            JavaExpr::Unary {
+                op: JavaUnaryOp::LogicalNot,
+                operand,
+            }
+            | JavaExpr::InstanceOf { value: operand, .. } => Self::pure_condition(operand),
+            JavaExpr::Binary { left, op, right } => {
+                !matches!(op, JavaBinaryOp::Divide | JavaBinaryOp::Remainder)
+                    && Self::pure_condition(left)
+                    && Self::pure_condition(right)
+            }
+            JavaExpr::Conditional {
+                condition,
+                when_true,
+                when_false,
+            } => {
+                Self::pure_condition(condition)
+                    && Self::pure_condition(when_true)
+                    && Self::pure_condition(when_false)
+            }
+            JavaExpr::Cast { .. }
+            | JavaExpr::Field { .. }
+            | JavaExpr::ArrayAccess { .. }
+            | JavaExpr::Call { .. }
+            | JavaExpr::MethodReference { .. }
+            | JavaExpr::Lambda { .. }
+            | JavaExpr::BlockLambda { .. }
+            | JavaExpr::New { .. }
+            | JavaExpr::NewArray { .. }
+            | JavaExpr::StaticField { .. }
+            | JavaExpr::Update { .. }
+            | JavaExpr::Assignment { .. }
+            | JavaExpr::Unary { .. } => false,
+        }
+    }
+
     fn strip_terminal_void_return(statement: &mut JavaStmt) -> bool {
         match statement {
             JavaStmt::Return(None) => {
@@ -646,39 +701,32 @@ impl ConditionalResultJoin {
     }
 
     fn candidate(window: &[JavaStmt]) -> Option<JavaStmt> {
-        let [
-            JavaStmt::Variable {
-                ty: JavaType::Primitive(JavaPrimitiveType::Boolean),
-                name,
-                value: Some(JavaExpr::Literal(JavaLiteral::Boolean(false))),
-            },
-            JavaStmt::If {
-                condition: guard,
-                then_stmt: guarded,
-                else_stmt: None,
-            },
-            JavaStmt::If {
-                condition: complement,
-                then_stmt: fallback,
-                else_stmt: None,
-            },
-        ] = window
+        let [JavaStmt::Variable {
+            ty: JavaType::Primitive(JavaPrimitiveType::Boolean),
+            name,
+            value: Some(JavaExpr::Literal(JavaLiteral::Boolean(false))),
+        }, JavaStmt::If {
+            condition: guard,
+            then_stmt: guarded,
+            else_stmt: None,
+        }, JavaStmt::If {
+            condition: complement,
+            then_stmt: fallback,
+            else_stmt: None,
+        }] = window
         else {
             return None;
         };
         let guarded = Self::statements(guarded)?;
-        let [
-            JavaStmt::Assign {
-                target: JavaExpr::Name(assigned),
-                op: JavaAssignOp::Assign,
-                value,
-            },
-            JavaStmt::If {
-                condition: JavaExpr::Name(tested),
-                then_stmt: success,
-                else_stmt: None,
-            },
-        ] = guarded
+        let [JavaStmt::Assign {
+            target: JavaExpr::Name(assigned),
+            op: JavaAssignOp::Assign,
+            value,
+        }, JavaStmt::If {
+            condition: JavaExpr::Name(tested),
+            then_stmt: success,
+            else_stmt: None,
+        }] = guarded
         else {
             return None;
         };
@@ -723,11 +771,7 @@ impl ConditionalResultJoin {
         }
     }
 
-    fn is_complement(
-        expression: &JavaExpr,
-        guard: &JavaExpr,
-        result: &JavaIdentifier,
-    ) -> bool {
+    fn is_complement(expression: &JavaExpr, guard: &JavaExpr, result: &JavaIdentifier) -> bool {
         let JavaExpr::Binary {
             left,
             op: JavaBinaryOp::LogicalOr,
@@ -771,11 +815,7 @@ impl ConditionalResultJoin {
                     condition,
                     when_true,
                     when_false,
-                } => pending.extend([
-                    condition.as_ref(),
-                    when_true.as_ref(),
-                    when_false.as_ref(),
-                ]),
+                } => pending.extend([condition.as_ref(), when_true.as_ref(), when_false.as_ref()]),
                 JavaExpr::Field { .. }
                 | JavaExpr::StaticField { .. }
                 | JavaExpr::ArrayAccess { .. }
@@ -792,7 +832,10 @@ impl ConditionalResultJoin {
         true
     }
 
-    fn collect_names(expression: &JavaExpr, names: &mut std::collections::BTreeSet<JavaIdentifier>) {
+    fn collect_names(
+        expression: &JavaExpr,
+        names: &mut std::collections::BTreeSet<JavaIdentifier>,
+    ) {
         struct Collector<'a>(&'a mut std::collections::BTreeSet<JavaIdentifier>);
         impl JavaAstRewriter for Collector<'_> {
             fn finish_expression(&mut self, expression: JavaExpr) -> JavaExpr {
@@ -855,8 +898,7 @@ impl StringSwitchRecovery {
         let mut changed = false;
         let mut index = 0usize;
         while index + 2 < statements.len() {
-            let Some((synthetic, replacement)) =
-                Self::candidate(&statements[index..index + 3])
+            let Some((synthetic, replacement)) = Self::candidate(&statements[index..index + 3])
             else {
                 index += 1;
                 continue;
@@ -877,23 +919,19 @@ impl StringSwitchRecovery {
     }
 
     fn candidate(window: &[JavaStmt]) -> Option<(JavaIdentifier, JavaStmt)> {
-        let [
-            JavaStmt::Variable {
-                ty: JavaType::Primitive(JavaPrimitiveType::Int),
-                name: synthetic,
-                value: Some(JavaExpr::Literal(JavaLiteral::Integer(initial))),
-            },
-            JavaStmt::Switch {
-                label: None,
-                selector: hash_selector,
-                cases: hash_cases,
-            },
-            JavaStmt::Switch {
-                label: None,
-                selector: JavaExpr::Name(action_selector),
-                cases: action_cases,
-            },
-        ] = window
+        let [JavaStmt::Variable {
+            ty: JavaType::Primitive(JavaPrimitiveType::Int),
+            name: synthetic,
+            value: Some(JavaExpr::Literal(JavaLiteral::Integer(initial))),
+        }, JavaStmt::Switch {
+            label: None,
+            selector: hash_selector,
+            cases: hash_cases,
+        }, JavaStmt::Switch {
+            label: None,
+            selector: JavaExpr::Name(action_selector),
+            cases: action_cases,
+        }] = window
         else {
             return None;
         };
@@ -953,9 +991,8 @@ impl StringSwitchRecovery {
                 let JavaExpr::Literal(JavaLiteral::Integer(selected)) = label else {
                     return None;
                 };
-                let Some((_, literal)) = mappings
-                    .iter()
-                    .find(|(candidate, _)| candidate == selected)
+                let Some((_, literal)) =
+                    mappings.iter().find(|(candidate, _)| candidate == selected)
                 else {
                     return None;
                 };
@@ -1007,19 +1044,15 @@ impl StringSwitchRecovery {
         source: &JavaIdentifier,
         initial: i32,
     ) -> Option<(&'a crate::ir::Utf16String, i32, i32)> {
-        let [
-            JavaStmt::If {
-                condition,
-                then_stmt,
-                else_stmt: None,
-            },
-            JavaStmt::Assign {
-                target: JavaExpr::Name(rejected_target),
-                op: JavaAssignOp::Assign,
-                value: JavaExpr::Literal(JavaLiteral::Integer(rejected)),
-            },
-            JavaStmt::Break(None),
-        ] = body
+        let [JavaStmt::If {
+            condition,
+            then_stmt,
+            else_stmt: None,
+        }, JavaStmt::Assign {
+            target: JavaExpr::Name(rejected_target),
+            op: JavaAssignOp::Assign,
+            value: JavaExpr::Literal(JavaLiteral::Integer(rejected)),
+        }, JavaStmt::Break(None)] = body
         else {
             return None;
         };
@@ -1066,27 +1099,25 @@ impl StringSwitchRecovery {
         };
         match statements {
             [JavaStmt::Break(None)] => Some(initial),
-            [
-                JavaStmt::Assign {
-                    target: JavaExpr::Name(target),
-                    op: JavaAssignOp::Assign,
-                    value: JavaExpr::Literal(JavaLiteral::Integer(value)),
-                },
-                JavaStmt::Break(None),
-            ] if target == synthetic => Some(*value),
+            [JavaStmt::Assign {
+                target: JavaExpr::Name(target),
+                op: JavaAssignOp::Assign,
+                value: JavaExpr::Literal(JavaLiteral::Integer(value)),
+            }, JavaStmt::Break(None)]
+                if target == synthetic =>
+            {
+                Some(*value)
+            }
             _ => None,
         }
     }
 
     fn fallback_selector(body: &[JavaStmt], synthetic: &JavaIdentifier) -> Option<i32> {
-        let [
-            JavaStmt::Assign {
-                target: JavaExpr::Name(target),
-                op: JavaAssignOp::Assign,
-                value: JavaExpr::Literal(JavaLiteral::Integer(value)),
-            },
-            JavaStmt::Break(None),
-        ] = body
+        let [JavaStmt::Assign {
+            target: JavaExpr::Name(target),
+            op: JavaAssignOp::Assign,
+            value: JavaExpr::Literal(JavaLiteral::Integer(value)),
+        }, JavaStmt::Break(None)] = body
         else {
             return None;
         };
@@ -1127,27 +1158,21 @@ impl SwitchResultReturn {
     }
 
     fn candidate(window: &[JavaStmt]) -> Option<JavaStmt> {
-        let [
-            JavaStmt::Variable {
-                name,
-                value: initializer,
-                ..
-            },
-            JavaStmt::Switch {
-                label: None,
-                selector,
-                cases,
-            },
-            terminal,
-        ] = window
+        let [JavaStmt::Variable {
+            name,
+            value: initializer,
+            ..
+        }, JavaStmt::Switch {
+            label: None,
+            selector,
+            cases,
+        }, terminal] = window
         else {
             return None;
         };
         let projection = match terminal {
             JavaStmt::Return(Some(JavaExpr::Name(returned))) if returned == name => None,
-            JavaStmt::Return(Some(JavaExpr::Cast { ty, value }))
-                if matches!(value.as_ref(), JavaExpr::Name(returned) if returned == name) =>
-            {
+            JavaStmt::Return(Some(JavaExpr::Cast { ty, value })) if matches!(value.as_ref(), JavaExpr::Name(returned) if returned == name) => {
                 Some(ty)
             }
             _ => return None,
@@ -1990,7 +2015,10 @@ mod tests {
         let JavaStmt::Block(statements) = &body.root else {
             panic!("expected method block");
         };
-        let JavaStmt::Variable { value: Some(value), .. } = &statements[0] else {
+        let JavaStmt::Variable {
+            value: Some(value), ..
+        } = &statements[0]
+        else {
             panic!("expected variable initializer");
         };
         assert_eq!(
@@ -2022,10 +2050,60 @@ mod tests {
         let JavaStmt::Block(statements) = &body.root else {
             panic!("expected method block");
         };
-        let JavaStmt::Variable { value: Some(value), .. } = &statements[0] else {
+        let JavaStmt::Variable {
+            value: Some(value), ..
+        } = &statements[0]
+        else {
             panic!("expected variable initializer");
         };
         assert_eq!(value, &expression);
+    }
+
+    #[test]
+    fn removes_pure_empty_if() {
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![
+                JavaStmt::If {
+                    condition: JavaExpr::Binary {
+                        left: Box::new(JavaExpr::Name(JavaIdentifier::from_dex("ready"))),
+                        op: JavaBinaryOp::Equal,
+                        right: Box::new(JavaExpr::Literal(JavaLiteral::Boolean(true))),
+                    },
+                    then_stmt: Box::new(JavaStmt::Empty),
+                    else_stmt: None,
+                },
+                marker("work"),
+            ]),
+        };
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        assert!(matches!(
+            body.root,
+            JavaStmt::Block(statements)
+                if statements.len() == 1
+                    && matches!(&statements[0], JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "work")
+        ));
+    }
+
+    #[test]
+    fn keeps_effectful_empty_if() {
+        let mut body = JavaMethodBody {
+            root: JavaStmt::Block(vec![JavaStmt::If {
+                condition: JavaExpr::Call {
+                    receiver: None,
+                    owner: None,
+                    type_arguments: Vec::new(),
+                    method: JavaIdentifier::from_dex("ready"),
+                    args: Vec::new(),
+                },
+                then_stmt: Box::new(JavaStmt::Empty),
+                else_stmt: None,
+            }]),
+        };
+        let original = body.clone();
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
     }
 
     #[test]
@@ -2202,8 +2280,12 @@ mod tests {
             } if left.as_ref() == &guard
                 && matches!(right.as_ref(), JavaExpr::Name(name) if name.as_str() == "predicate")
         ));
-        assert!(matches!(then_stmt.as_ref(), JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "success"));
-        assert!(matches!(else_stmt.as_ref(), JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "fallback"));
+        assert!(
+            matches!(then_stmt.as_ref(), JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "success")
+        );
+        assert!(
+            matches!(else_stmt.as_ref(), JavaStmt::Expression(JavaExpr::Name(name)) if name.as_str() == "fallback")
+        );
     }
 
     #[test]
@@ -2271,9 +2353,7 @@ mod tests {
         let synthetic = JavaIdentifier::from_dex("selector");
         let hash_case = |literal: &str, selected: i32| JavaSwitchCase {
             labels: vec![JavaExpr::Literal(JavaLiteral::Integer(
-                StringSwitchRecovery::string_hash(
-                    &literal.encode_utf16().collect::<Vec<_>>(),
-                ),
+                StringSwitchRecovery::string_hash(&literal.encode_utf16().collect::<Vec<_>>()),
             ))],
             body: vec![
                 JavaStmt::If {
@@ -2309,10 +2389,7 @@ mod tests {
                         hash_case("beta", 1),
                         JavaSwitchCase {
                             labels: Vec::new(),
-                            body: vec![
-                                assign_integer(&synthetic, -1),
-                                JavaStmt::Break(None),
-                            ],
+                            body: vec![assign_integer(&synthetic, -1), JavaStmt::Break(None)],
                             is_default: true,
                         },
                     ],
@@ -2408,7 +2485,10 @@ mod tests {
         let JavaStmt::Block(statements) = &body.root else {
             unreachable!();
         };
-        assert!(matches!(statements.first(), Some(JavaStmt::Variable { .. })));
+        assert!(matches!(
+            statements.first(),
+            Some(JavaStmt::Variable { .. })
+        ));
     }
 
     fn result_switch(has_default: bool, initializer: Option<JavaExpr>) -> JavaMethodBody {

--- a/dexdec/src/language/java/normalize.rs
+++ b/dexdec/src/language/java/normalize.rs
@@ -1,5 +1,5 @@
 use super::{
-    JavaAstRewriter, JavaBinaryOp, JavaCatch, JavaExpr, JavaIdentifier, JavaLiteral,
+    JavaAssignOp, JavaAstRewriter, JavaBinaryOp, JavaCatch, JavaExpr, JavaIdentifier, JavaLiteral,
     JavaMethodBody, JavaPrimitiveType, JavaStmt, JavaSwitchCase, JavaType,
 };
 
@@ -244,6 +244,7 @@ impl JavaAstNormalizer {
                 child => flattened.push(child),
             }
         }
+        changed |= SwitchResultReturn::apply(&mut flattened);
         changed |= TerminalBranchLinearizer::apply(&mut flattened);
         (flattened, changed)
     }
@@ -531,6 +532,152 @@ impl JavaAstNormalizer {
             JavaStmt::Synchronized { body, .. } => Self::strip_terminal_void_return(body),
             _ => false,
         }
+    }
+}
+
+/// Replaces a synthetic result local around a total switch with direct returns.
+///
+/// DEX has no expression-valued switch, so value recovery can naturally produce
+/// `T result = null; switch (...) { case ...: result = value; break; } return result;`.
+/// Once every switch entry is known to terminate, keeping the accumulator only
+/// obscures the original source shape. This rewrite is deliberately conservative:
+/// it requires a side-effect-free initializer, a default case, and no other use
+/// of the local.
+struct SwitchResultReturn;
+
+impl SwitchResultReturn {
+    fn apply(statements: &mut Vec<JavaStmt>) -> bool {
+        let mut changed = false;
+        let mut index = 0usize;
+        while index + 2 < statements.len() {
+            let Some(replacement) = Self::candidate(&statements[index..index + 3]) else {
+                index += 1;
+                continue;
+            };
+            statements.splice(index..index + 3, std::iter::once(replacement));
+            changed = true;
+            index += 1;
+        }
+        changed
+    }
+
+    fn candidate(window: &[JavaStmt]) -> Option<JavaStmt> {
+        let [
+            JavaStmt::Variable {
+                name,
+                value: initializer,
+                ..
+            },
+            JavaStmt::Switch {
+                label: None,
+                selector,
+                cases,
+            },
+            terminal,
+        ] = window
+        else {
+            return None;
+        };
+        let projection = match terminal {
+            JavaStmt::Return(Some(JavaExpr::Name(returned))) if returned == name => None,
+            JavaStmt::Return(Some(JavaExpr::Cast { ty, value }))
+                if matches!(value.as_ref(), JavaExpr::Name(returned) if returned == name) =>
+            {
+                Some(ty)
+            }
+            _ => return None,
+        };
+        if !initializer
+            .as_ref()
+            .is_none_or(|value| matches!(value, JavaExpr::Literal(_)))
+            || !cases.iter().any(|case| case.is_default)
+            || Self::expression_uses(selector, name)
+        {
+            return None;
+        }
+
+        let mut cases = cases.clone();
+        for case in &mut cases {
+            if case
+                .labels
+                .iter()
+                .any(|label| Self::expression_uses(label, name))
+                || !Self::rewrite_case(&mut case.body, name, projection)
+            {
+                return None;
+            }
+        }
+        if TerminalBranchLinearizer::switch_can_complete_normally(None, &cases) {
+            return None;
+        }
+        Some(JavaStmt::Switch {
+            label: None,
+            selector: selector.clone(),
+            cases,
+        })
+    }
+
+    fn rewrite_case(
+        body: &mut Vec<JavaStmt>,
+        target: &JavaIdentifier,
+        projection: Option<&JavaType>,
+    ) -> bool {
+        if body.is_empty() {
+            // An empty case falls through to the next case. The final completion
+            // check below proves that it still reaches a terminal case body.
+            return true;
+        }
+
+        if matches!(body.last(), Some(JavaStmt::Return(_) | JavaStmt::Throw(_))) {
+            return !body
+                .iter()
+                .any(|statement| Self::statement_uses(statement, target));
+        }
+
+        let Some(JavaStmt::Break(None)) = body.last() else {
+            return false;
+        };
+        let Some(JavaStmt::Assign {
+            target: JavaExpr::Name(assigned),
+            op: JavaAssignOp::Assign,
+            value,
+        }) = body.get(body.len().saturating_sub(2))
+        else {
+            return false;
+        };
+        if assigned != target
+            || Self::expression_uses(value, target)
+            || body[..body.len() - 2]
+                .iter()
+                .any(|statement| Self::statement_uses(statement, target))
+        {
+            return false;
+        }
+
+        let value = match projection {
+            Some(ty) if !matches!(value, JavaExpr::Cast { ty: cast, .. } if cast == ty) => {
+                JavaExpr::Cast {
+                    ty: ty.clone(),
+                    value: Box::new(value.clone()),
+                }
+            }
+            _ => value.clone(),
+        };
+        body.truncate(body.len() - 2);
+        body.push(JavaStmt::Return(Some(value)));
+        true
+    }
+
+    fn expression_uses(expression: &JavaExpr, target: &JavaIdentifier) -> bool {
+        let mut counter = NameUseCounter { target, count: 0 };
+        counter.rewrite_expression(expression.clone());
+        counter.count != 0
+    }
+
+    fn statement_uses(statement: &JavaStmt, target: &JavaIdentifier) -> bool {
+        let mut counter = NameUseCounter { target, count: 0 };
+        counter.rewrite_statement(statement.clone());
+        counter.count != 0
     }
 }
 
@@ -1197,6 +1344,135 @@ impl JavaAstRewriter for NameUseCounter<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn result_switch(has_default: bool, initializer: Option<JavaExpr>) -> JavaMethodBody {
+        let result = JavaIdentifier::from_dex("result");
+        JavaMethodBody {
+            root: JavaStmt::Block(vec![
+                JavaStmt::Variable {
+                    ty: JavaType::Variable(JavaIdentifier::from_dex("T")),
+                    name: result.clone(),
+                    value: initializer,
+                },
+                JavaStmt::Switch {
+                    label: None,
+                    selector: JavaExpr::Name(JavaIdentifier::from_dex("selector")),
+                    cases: vec![
+                        JavaSwitchCase {
+                            labels: vec![JavaExpr::Literal(JavaLiteral::Integer(0))],
+                            body: vec![
+                                JavaStmt::Assign {
+                                    target: JavaExpr::Name(result.clone()),
+                                    op: JavaAssignOp::Assign,
+                                    value: JavaExpr::Name(JavaIdentifier::from_dex("first")),
+                                },
+                                JavaStmt::Break(None),
+                            ],
+                            is_default: false,
+                        },
+                        JavaSwitchCase {
+                            labels: Vec::new(),
+                            body: vec![JavaStmt::Throw(JavaExpr::Name(JavaIdentifier::from_dex(
+                                "invalid",
+                            )))],
+                            is_default: has_default,
+                        },
+                    ],
+                },
+                JavaStmt::Return(Some(JavaExpr::Name(result))),
+            ]),
+        }
+    }
+
+    #[test]
+    fn total_switch_returns_values_directly() {
+        let mut body = result_switch(true, Some(JavaExpr::Literal(JavaLiteral::Null)));
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let [JavaStmt::Switch { cases, .. }] = statements.as_slice() else {
+            panic!("expected direct switch");
+        };
+        assert!(matches!(
+            cases[0].body.as_slice(),
+            [JavaStmt::Return(Some(JavaExpr::Name(value)))] if value.as_str() == "first"
+        ));
+        assert!(matches!(cases[1].body.as_slice(), [JavaStmt::Throw(_)]));
+    }
+
+    #[test]
+    fn total_switch_preserves_final_result_cast() {
+        let mut body = result_switch(true, Some(JavaExpr::Literal(JavaLiteral::Null)));
+        let JavaStmt::Block(statements) = &mut body.root else {
+            unreachable!();
+        };
+        statements[2] = JavaStmt::Return(Some(JavaExpr::Cast {
+            ty: JavaType::Variable(JavaIdentifier::from_dex("R")),
+            value: Box::new(JavaExpr::Name(JavaIdentifier::from_dex("result"))),
+        }));
+
+        assert!(JavaAstNormalizer.apply(&mut body).unwrap());
+        let JavaStmt::Block(statements) = &body.root else {
+            panic!("expected method block");
+        };
+        let [JavaStmt::Switch { cases, .. }] = statements.as_slice() else {
+            panic!("expected direct switch");
+        };
+        assert!(matches!(
+            cases[0].body.as_slice(),
+            [JavaStmt::Return(Some(JavaExpr::Cast { ty: JavaType::Variable(ty), value }))]
+                if ty.as_str() == "R"
+                    && matches!(value.as_ref(), JavaExpr::Name(name) if name.as_str() == "first")
+        ));
+    }
+
+    #[test]
+    fn switch_result_local_is_kept_without_default_case() {
+        let mut body = result_switch(false, Some(JavaExpr::Literal(JavaLiteral::Null)));
+        let original = body.clone();
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
+    }
+
+    #[test]
+    fn switch_result_local_is_kept_when_initializer_has_effects() {
+        let mut body = result_switch(
+            true,
+            Some(JavaExpr::Call {
+                receiver: None,
+                owner: None,
+                type_arguments: Vec::new(),
+                method: JavaIdentifier::from_dex("initialize"),
+                args: Vec::new(),
+            }),
+        );
+        let original = body.clone();
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
+    }
+
+    #[test]
+    fn switch_result_local_is_kept_when_a_case_reads_it() {
+        let mut body = result_switch(true, Some(JavaExpr::Literal(JavaLiteral::Null)));
+        let JavaStmt::Block(statements) = &mut body.root else {
+            unreachable!();
+        };
+        let JavaStmt::Switch { cases, .. } = &mut statements[1] else {
+            unreachable!();
+        };
+        let JavaStmt::Assign { value, .. } = &mut cases[0].body[0] else {
+            unreachable!();
+        };
+        *value = JavaExpr::Name(JavaIdentifier::from_dex("result"));
+        let original = body.clone();
+
+        assert!(!JavaAstNormalizer.apply(&mut body).unwrap());
+        assert_eq!(body.root, original.root);
+    }
 
     #[test]
     fn removes_try_with_only_an_empty_finally() {


### PR DESCRIPTION
## Summary

- infer null-select reference types, erase non-denotable method bounds, and isolate nested field namespaces
- preserve case-colliding source files when writing a class shard to disk
- keep Kotlin reification markers and non-void call results from dropping their continuations
- return switch results directly, join complementary boolean branches, flatten terminal void tails, and reconstruct lowered string switches
- preserve cmp operand evaluation and simplify repeated stable conditional arms
- materialize shared vacuous predicate values before they are replayed by a later effect

This is one Java emission and semantic-normalization pipeline presented as 13 scoped commits. The CLI case-collision change is merged with the existing fail-soft save path so a write error still skips the rest of the shard only when `--fail-fast` is off.

Two earlier exception-cleanup commits remain on the ledger: they regress `syncWithFinally` / structured `finally` when stacked on current main.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p dexdec -p dexdec-workbench -p dexdec-mcp`
- `cargo test -p dexdec --lib` (569 passed)
- 36 added regression scenarios
- `cargo test -p dexdec --test expected_test`
- `cargo test -p dexdec --test cli_args_test`
- `node --test scripts/version.test.mjs` and `node scripts/version.mjs check`

## Review notes

The commits move from Java type legality through CLI output identity to switch/branch reconstruction, so they can be reviewed in that order.