### PR TITLE
Name leftover source locals without vN fallbacks

### DIFF
--- a/dexdec/src/analysis/jadx_local_names.rs
+++ b/dexdec/src/analysis/jadx_local_names.rs
@@ -1,0 +1,246 @@
+//! Local names that follow JADX's `ApplyVariableNames` and
+//! `ProcessKotlinInternals` rules.
+//!
+//! JADX never falls back to a DEX register (`v12`). It names a local from a
+//! Kotlin `Intrinsics` check string when one exists, otherwise from the value's
+//! type or defining call.
+
+use std::collections::BTreeMap;
+
+use crate::ir::{
+    ArgType, InsnType, LiteralArg, MemberReference, PrimitiveType, SemanticExpression,
+    SemanticNode, SemanticOperation, SemanticVisitor,
+};
+
+const OBJECT_ALIASES: &[(&str, &str)] = &[
+    ("java.lang.String", "str"),
+    ("kotlin.String", "str"),
+    ("java.lang.Class", "cls"),
+    ("java.lang.Throwable", "th"),
+    ("java.lang.Object", "obj"),
+    ("kotlin.Any", "obj"),
+    ("java.util.Iterator", "it"),
+    ("kotlin.collections.Iterator", "it"),
+    ("java.util.HashMap", "map"),
+    ("java.lang.Boolean", "bool"),
+    ("java.lang.Short", "sh"),
+    ("java.lang.Integer", "num"),
+    ("java.lang.Character", "ch"),
+    ("java.lang.Byte", "b"),
+    ("java.lang.Float", "f"),
+    ("java.lang.Long", "l"),
+    ("java.lang.Double", "d"),
+    ("java.lang.StringBuilder", "sb"),
+    ("java.lang.Exception", "exc"),
+];
+
+const INVOKE_PREFIXES: &[&str] = &["get", "set", "to", "parse", "read", "format"];
+
+pub(crate) fn primitive_local_name(primitive: PrimitiveType) -> Option<&'static str> {
+    match primitive {
+        PrimitiveType::Boolean => Some("z"),
+        PrimitiveType::Byte => Some("b"),
+        PrimitiveType::Short => Some("s"),
+        PrimitiveType::Char => Some("c"),
+        PrimitiveType::Int => Some("i"),
+        PrimitiveType::Long => Some("j"),
+        PrimitiveType::Float => Some("f"),
+        PrimitiveType::Double => Some("d"),
+        PrimitiveType::Void | PrimitiveType::Object | PrimitiveType::Array => None,
+    }
+}
+
+pub(crate) fn object_alias(qualified: &str) -> Option<&'static str> {
+    OBJECT_ALIASES
+        .iter()
+        .find(|(name, _)| *name == qualified)
+        .map(|(_, alias)| *alias)
+}
+
+pub(crate) fn class_local_name(simple: &str) -> String {
+    if simple.is_empty() {
+        return "obj".to_string();
+    }
+    let alphabetic = simple
+        .chars()
+        .filter(|character| character.is_alphabetic())
+        .collect::<Vec<_>>();
+    if !alphabetic.is_empty() && alphabetic.iter().all(|character| character.is_uppercase()) {
+        return simple.to_lowercase();
+    }
+    let mut characters = simple.chars();
+    let Some(first) = characters.next() else {
+        return "obj".to_string();
+    };
+    let mut lowered = first.to_lowercase().collect::<String>();
+    lowered.extend(characters);
+    if lowered != simple {
+        return lowered;
+    }
+    format!("{simple}Var")
+}
+
+pub(crate) fn array_local_name(element: &str) -> String {
+    format!("{element}Arr")
+}
+
+pub(crate) fn class_local_name_from_segments<'a>(
+    segments: impl IntoIterator<Item = &'a str>,
+) -> String {
+    let segments = segments.into_iter().collect::<Vec<_>>();
+    let qualified = segments.join(".");
+    if let Some(alias) = object_alias(&qualified) {
+        return alias.to_string();
+    }
+    class_local_name(segments.last().copied().unwrap_or(""))
+}
+
+pub(crate) fn trim_intrinsic_name(name: &str) -> &str {
+    name.strip_prefix("$this$")
+        .or_else(|| name.strip_prefix('$'))
+        .unwrap_or(name)
+}
+
+pub(crate) fn invoke_local_name(method: &str) -> Option<String> {
+    if method == "iterator" {
+        return Some("it".to_string());
+    }
+    if method == "getInstance" {
+        return None;
+    }
+    for prefix in INVOKE_PREFIXES {
+        if let Some(rest) = method.strip_prefix(prefix) {
+            if rest
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_uppercase())
+            {
+                return Some(class_local_name(rest));
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn intrinsic_local_names(root: &SemanticNode) -> BTreeMap<u32, String> {
+    let mut collector = IntrinsicNameCollector::default();
+    collector.visit_node(root);
+    collector.names
+}
+
+#[derive(Default)]
+struct IntrinsicNameCollector {
+    names: BTreeMap<u32, String>,
+}
+
+impl SemanticVisitor for IntrinsicNameCollector {
+    fn enter_operation(&mut self, operation: &SemanticOperation) {
+        if let Some((variable, name)) = intrinsic_binding(operation) {
+            self.names.entry(variable).or_insert(name);
+        }
+    }
+}
+
+fn intrinsic_binding(operation: &SemanticOperation) -> Option<(u32, String)> {
+    if operation.insn_type != InsnType::Invoke {
+        return None;
+    }
+    let MemberReference::Method(method) = operation.payload.reference.as_ref()? else {
+        return None;
+    };
+    if !is_kotlin_varname_source(method) {
+        return None;
+    }
+    let operands = operation.operands();
+    if operands.len() < 2 {
+        return None;
+    }
+    let variable = register_variable(&operands[0])?;
+    let name = const_string(operands.last()?)?;
+    let name = trim_intrinsic_name(&name);
+    if name.is_empty() {
+        return None;
+    }
+    Some((variable, name.to_string()))
+}
+
+fn is_kotlin_varname_source(method: &crate::ir::MethodReference) -> bool {
+    let parameters = &method.descriptor.parameters;
+    if method.descriptor.return_type != ArgType::VOID {
+        return false;
+    }
+    let string = ArgType::object("java/lang/String");
+    let object = ArgType::object("java/lang/Object");
+    let signature_ok = matches!(
+        parameters.as_slice(),
+        [left, right] if left == &object && right == &string
+    ) || matches!(
+        parameters.as_slice(),
+        [left, middle, right] if left == &object && middle == &string && right == &string
+    );
+    if !signature_ok {
+        return false;
+    }
+    let owner = method.owner.as_object().unwrap_or("");
+    owner == "kotlin/jvm/internal/Intrinsics"
+        || owner.ends_with("/Intrinsics")
+        || method.name.starts_with("checkNotNull")
+        || method.name.starts_with("checkParameterIsNotNull")
+        || method.name.starts_with("checkExpressionValueIsNotNull")
+}
+
+fn register_variable(expression: &SemanticExpression) -> Option<u32> {
+    match expression {
+        SemanticExpression::Register(register) => register.code_var,
+        _ => None,
+    }
+}
+
+fn const_string(expression: &SemanticExpression) -> Option<String> {
+    match expression {
+        SemanticExpression::Operation(operation) if operation.insn_type == InsnType::ConstStr => {
+            Some(operation.payload.string_value.as_ref()?.to_string_lossy())
+        }
+        SemanticExpression::Literal(LiteralArg { .. }) => None,
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_names_match_jadx_short_names() {
+        assert_eq!(primitive_local_name(PrimitiveType::Int), Some("i"));
+        assert_eq!(primitive_local_name(PrimitiveType::Boolean), Some("z"));
+        assert_eq!(primitive_local_name(PrimitiveType::Long), Some("j"));
+    }
+
+    #[test]
+    fn object_aliases_match_jadx() {
+        assert_eq!(object_alias("java.lang.String"), Some("str"));
+        assert_eq!(object_alias("java.lang.Object"), Some("obj"));
+        assert_eq!(object_alias("kotlin.Any"), Some("obj"));
+    }
+
+    #[test]
+    fn class_and_array_names_match_jadx() {
+        assert_eq!(class_local_name("FooBar"), "fooBar");
+        assert_eq!(class_local_name("HTML"), "html");
+        assert_eq!(class_local_name("v0"), "v0Var");
+        assert_eq!(array_local_name("i"), "iArr");
+        assert_eq!(
+            class_local_name_from_segments(["java", "lang", "String"]),
+            "str"
+        );
+    }
+
+    #[test]
+    fn intrinsic_and_invoke_names_match_jadx() {
+        assert_eq!(trim_intrinsic_name("$this$foo"), "foo");
+        assert_eq!(trim_intrinsic_name("$view"), "view");
+        assert_eq!(invoke_local_name("getView"), Some("view".to_string()));
+        assert_eq!(invoke_local_name("iterator"), Some("it".to_string()));
+    }
+}

--- a/dexdec/src/analysis/java_backend/semantic_naming.rs
+++ b/dexdec/src/analysis/java_backend/semantic_naming.rs
@@ -1,13 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::analysis::jadx_local_names;
 use crate::ir::{
     analysis::{
         StructuralVariableRoleAnalysis, VariableNode, VariableRole, VariableRoleAnalysis,
         VariableRoleScores, VariableSemanticGraph,
     },
-    ArgType, InsnType, MemberReference, SemanticNode,
+    ArgType, InsnType, MemberReference, PrimitiveType, SemanticNode,
 };
-use crate::language::java::{JavaIdentifier, JavaType};
+use crate::language::java::{JavaIdentifier, JavaPrimitiveType, JavaType};
 
 use super::type_names::JavaTypeNameResolver;
 
@@ -106,15 +107,9 @@ impl MethodResultSemantics for JavaMethodResultSemantics {
             return None;
         }
         let identifier = JavaIdentifier::from_hint(name);
-        if let Some(noun) = name.strip_prefix("get").filter(|noun| {
-            noun.chars()
-                .next()
-                .is_some_and(|character| character.is_ascii_uppercase())
-        }) {
+        if let Some(name) = jadx_local_names::invoke_local_name(name) {
             return Some(NameCandidate {
-                name: self
-                    .morphology
-                    .lower_camel(&JavaIdentifier::from_hint(noun)),
+                name: JavaIdentifier::from_hint(&name),
                 score: 85,
             });
         }
@@ -188,23 +183,7 @@ impl<'a> StructuralNameModel<'a> {
     }
 
     fn java_type_name(&self, ty: &JavaType) -> Option<JavaIdentifier> {
-        match ty {
-            JavaType::Class(class) => {
-                let name = &class.segments.last()?.name;
-                let source = name.as_str();
-                (source != "Object" && !is_register_style_name(source))
-                    .then(|| self.morphology.lower_camel(name))
-            }
-            JavaType::Array(element) => self
-                .java_type_name(element)
-                .map(|name| self.morphology.plural(&name))
-                .or_else(|| Some(JavaIdentifier::from_hint("values"))),
-            JavaType::Variable(name) => Some(self.morphology.lower_camel(name)),
-            JavaType::Primitive(crate::language::java::JavaPrimitiveType::Boolean) => {
-                Some(JavaIdentifier::from_hint("flag"))
-            }
-            JavaType::Primitive(_) => None,
-        }
+        Some(JavaIdentifier::from_hint(&java_jadx_type_name(ty)?))
     }
 
     fn lower_camel(name: &JavaIdentifier) -> JavaIdentifier {
@@ -429,9 +408,7 @@ impl<'a> ParameterNameRecovery<'a> {
     }
 
     pub(super) fn candidate(&self, ty: &ArgType) -> Option<JavaIdentifier> {
-        ty.is_reference()
-            .then(|| self.model.type_name(ty))
-            .flatten()
+        self.model.type_name(ty)
     }
 }
 
@@ -552,16 +529,23 @@ impl<'a> SemanticNameRecovery<'a> {
     ) -> BTreeMap<u32, JavaIdentifier> {
         let graph = VariableSemanticGraph::analyze(root, source_types);
         let roles = StructuralVariableRoleAnalysis.analyze(&graph);
+        let intrinsic_names = jadx_local_names::intrinsic_local_names(root);
         let excluded = parameter_variables
             .iter()
             .copied()
             .flatten()
             .chain(this_variable)
+            .chain(intrinsic_names.keys().copied())
             .collect::<BTreeSet<_>>();
         let model = StructuralNameModel::for_graph(self.types, &graph);
         let mut names =
             ConstrainedNameSolver::new(StructuralNameModel::for_graph(self.types, &graph), 35)
                 .solve(&graph, &roles, parameter_names, &excluded);
+        for (identity, name) in intrinsic_names {
+            names
+                .entry(identity)
+                .or_insert_with(|| JavaIdentifier::from_hint(&name));
+        }
         fill_remaining_source_names(
             &graph,
             &roles,
@@ -574,10 +558,33 @@ impl<'a> SemanticNameRecovery<'a> {
     }
 }
 
-fn is_register_style_name(name: &str) -> bool {
-    name.strip_prefix('v').is_some_and(|digits| {
-        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
-    })
+fn java_jadx_type_name(ty: &JavaType) -> Option<String> {
+    match ty {
+        JavaType::Primitive(primitive) => {
+            jadx_local_names::primitive_local_name(java_primitive(*primitive)).map(str::to_string)
+        }
+        JavaType::Class(class) => Some(jadx_local_names::class_local_name_from_segments(
+            class.segments.iter().map(|segment| segment.name.as_str()),
+        )),
+        JavaType::Variable(name) => Some(jadx_local_names::class_local_name(name.as_str())),
+        JavaType::Array(element) => Some(jadx_local_names::array_local_name(&java_jadx_type_name(
+            element,
+        )?)),
+    }
+}
+
+fn java_primitive(primitive: JavaPrimitiveType) -> PrimitiveType {
+    match primitive {
+        JavaPrimitiveType::Void => PrimitiveType::Void,
+        JavaPrimitiveType::Boolean => PrimitiveType::Boolean,
+        JavaPrimitiveType::Byte => PrimitiveType::Byte,
+        JavaPrimitiveType::Short => PrimitiveType::Short,
+        JavaPrimitiveType::Char => PrimitiveType::Char,
+        JavaPrimitiveType::Int => PrimitiveType::Int,
+        JavaPrimitiveType::Long => PrimitiveType::Long,
+        JavaPrimitiveType::Float => PrimitiveType::Float,
+        JavaPrimitiveType::Double => PrimitiveType::Double,
+    }
 }
 
 fn fill_remaining_source_names(

--- a/dexdec/src/analysis/java_backend/semantic_naming.rs
+++ b/dexdec/src/analysis/java_backend/semantic_naming.rs
@@ -191,7 +191,9 @@ impl<'a> StructuralNameModel<'a> {
         match ty {
             JavaType::Class(class) => {
                 let name = &class.segments.last()?.name;
-                (name.as_str() != "Object").then(|| self.morphology.lower_camel(name))
+                let source = name.as_str();
+                (source != "Object" && !is_register_style_name(source))
+                    .then(|| self.morphology.lower_camel(name))
             }
             JavaType::Array(element) => self
                 .java_type_name(element)
@@ -556,11 +558,64 @@ impl<'a> SemanticNameRecovery<'a> {
             .flatten()
             .chain(this_variable)
             .collect::<BTreeSet<_>>();
-        ConstrainedNameSolver::new(StructuralNameModel::for_graph(self.types, &graph), 35).solve(
+        let model = StructuralNameModel::for_graph(self.types, &graph);
+        let mut names =
+            ConstrainedNameSolver::new(StructuralNameModel::for_graph(self.types, &graph), 35)
+                .solve(&graph, &roles, parameter_names, &excluded);
+        fill_remaining_source_names(
             &graph,
             &roles,
+            &model,
             parameter_names,
             &excluded,
-        )
+            &mut names,
+        );
+        names
+    }
+}
+
+fn is_register_style_name(name: &str) -> bool {
+    name.strip_prefix('v').is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+fn fill_remaining_source_names(
+    graph: &VariableSemanticGraph,
+    roles: &VariableRoleScores,
+    model: &StructuralNameModel<'_>,
+    reserved: &[JavaIdentifier],
+    excluded: &BTreeSet<u32>,
+    names: &mut BTreeMap<u32, JavaIdentifier>,
+) {
+    let mut used = names.values().cloned().collect::<BTreeSet<_>>();
+    for name in reserved {
+        used.insert(name.clone());
+    }
+    for variable in graph.variables() {
+        if !variable.is_source_binding() || excluded.contains(&variable.identity()) {
+            continue;
+        }
+        if names.contains_key(&variable.identity()) {
+            continue;
+        }
+        let preferred = model
+            .type_name(variable.ty())
+            .or_else(|| {
+                roles
+                    .roles(variable.identity())
+                    .max_by_key(|(_, score)| *score)
+                    .filter(|(_, score)| *score > 0)
+                    .map(|(role, _)| {
+                        JavaIdentifier::from_hint(StructuralNameModel::role_name(role))
+                    })
+            })
+            .unwrap_or_else(|| JavaIdentifier::from_hint("value"));
+        let name = if used.insert(preferred.clone()) {
+            preferred
+        } else {
+            ConstrainedNameSolver::<StructuralNameModel>::claim_variant(&preferred, &mut used)
+        };
+        names.insert(variable.identity(), name);
     }
 }

--- a/dexdec/src/analysis/kotlin_backend/semantic_naming.rs
+++ b/dexdec/src/analysis/kotlin_backend/semantic_naming.rs
@@ -191,7 +191,9 @@ impl<'a> StructuralNameModel<'a> {
         match ty {
             KotlinType::Class(class) => {
                 let name = &class.segments.last()?.name;
-                (name.as_str() != "Object").then(|| self.morphology.lower_camel(name))
+                let source = name.as_str();
+                (source != "Object" && !is_register_style_name(source))
+                    .then(|| self.morphology.lower_camel(name))
             }
             KotlinType::Array(element) => self
                 .java_type_name(element)
@@ -556,11 +558,64 @@ impl<'a> SemanticNameRecovery<'a> {
             .flatten()
             .chain(this_variable)
             .collect::<BTreeSet<_>>();
-        ConstrainedNameSolver::new(StructuralNameModel::for_graph(self.types, &graph), 35).solve(
+        let model = StructuralNameModel::for_graph(self.types, &graph);
+        let mut names =
+            ConstrainedNameSolver::new(StructuralNameModel::for_graph(self.types, &graph), 35)
+                .solve(&graph, &roles, parameter_names, &excluded);
+        fill_remaining_source_names(
             &graph,
             &roles,
+            &model,
             parameter_names,
             &excluded,
-        )
+            &mut names,
+        );
+        names
+    }
+}
+
+fn is_register_style_name(name: &str) -> bool {
+    name.strip_prefix('v').is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+fn fill_remaining_source_names(
+    graph: &VariableSemanticGraph,
+    roles: &VariableRoleScores,
+    model: &StructuralNameModel<'_>,
+    reserved: &[KotlinIdentifier],
+    excluded: &BTreeSet<u32>,
+    names: &mut BTreeMap<u32, KotlinIdentifier>,
+) {
+    let mut used = names.values().cloned().collect::<BTreeSet<_>>();
+    for name in reserved {
+        used.insert(name.clone());
+    }
+    for variable in graph.variables() {
+        if !variable.is_source_binding() || excluded.contains(&variable.identity()) {
+            continue;
+        }
+        if names.contains_key(&variable.identity()) {
+            continue;
+        }
+        let preferred = model
+            .type_name(variable.ty())
+            .or_else(|| {
+                roles
+                    .roles(variable.identity())
+                    .max_by_key(|(_, score)| *score)
+                    .filter(|(_, score)| *score > 0)
+                    .map(|(role, _)| {
+                        KotlinIdentifier::from_hint(StructuralNameModel::role_name(role))
+                    })
+            })
+            .unwrap_or_else(|| KotlinIdentifier::from_hint("value"));
+        let name = if used.insert(preferred.clone()) {
+            preferred
+        } else {
+            ConstrainedNameSolver::<StructuralNameModel>::claim_variant(&preferred, &mut used)
+        };
+        names.insert(variable.identity(), name);
     }
 }

--- a/dexdec/src/analysis/kotlin_backend/semantic_naming.rs
+++ b/dexdec/src/analysis/kotlin_backend/semantic_naming.rs
@@ -1,13 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::analysis::jadx_local_names;
 use crate::ir::{
     analysis::{
         StructuralVariableRoleAnalysis, VariableNode, VariableRole, VariableRoleAnalysis,
         VariableRoleScores, VariableSemanticGraph,
     },
-    ArgType, InsnType, MemberReference, SemanticNode,
+    ArgType, InsnType, MemberReference, PrimitiveType, SemanticNode,
 };
-use crate::language::kotlin::{KotlinIdentifier, KotlinType};
+use crate::language::kotlin::{KotlinIdentifier, KotlinPrimitiveType, KotlinType};
 
 use super::type_names::KotlinTypeNameResolver;
 
@@ -106,15 +107,9 @@ impl MethodResultSemantics for KotlinMethodResultSemantics {
             return None;
         }
         let identifier = KotlinIdentifier::from_hint(name);
-        if let Some(noun) = name.strip_prefix("get").filter(|noun| {
-            noun.chars()
-                .next()
-                .is_some_and(|character| character.is_ascii_uppercase())
-        }) {
+        if let Some(name) = jadx_local_names::invoke_local_name(name) {
             return Some(NameCandidate {
-                name: self
-                    .morphology
-                    .lower_camel(&KotlinIdentifier::from_hint(noun)),
+                name: KotlinIdentifier::from_hint(&name),
                 score: 85,
             });
         }
@@ -188,23 +183,7 @@ impl<'a> StructuralNameModel<'a> {
     }
 
     fn java_type_name(&self, ty: &KotlinType) -> Option<KotlinIdentifier> {
-        match ty {
-            KotlinType::Class(class) => {
-                let name = &class.segments.last()?.name;
-                let source = name.as_str();
-                (source != "Object" && !is_register_style_name(source))
-                    .then(|| self.morphology.lower_camel(name))
-            }
-            KotlinType::Array(element) => self
-                .java_type_name(element)
-                .map(|name| self.morphology.plural(&name))
-                .or_else(|| Some(KotlinIdentifier::from_hint("values"))),
-            KotlinType::Variable(name) => Some(self.morphology.lower_camel(name)),
-            KotlinType::Primitive(crate::language::kotlin::KotlinPrimitiveType::Boolean) => {
-                Some(KotlinIdentifier::from_hint("flag"))
-            }
-            KotlinType::Primitive(_) => None,
-        }
+        Some(KotlinIdentifier::from_hint(&kotlin_jadx_type_name(ty)?))
     }
 
     fn lower_camel(name: &KotlinIdentifier) -> KotlinIdentifier {
@@ -429,9 +408,7 @@ impl<'a> ParameterNameRecovery<'a> {
     }
 
     pub(super) fn candidate(&self, ty: &ArgType) -> Option<KotlinIdentifier> {
-        ty.is_reference()
-            .then(|| self.model.type_name(ty))
-            .flatten()
+        self.model.type_name(ty)
     }
 }
 
@@ -552,16 +529,23 @@ impl<'a> SemanticNameRecovery<'a> {
     ) -> BTreeMap<u32, KotlinIdentifier> {
         let graph = VariableSemanticGraph::analyze(root, source_types);
         let roles = StructuralVariableRoleAnalysis.analyze(&graph);
+        let intrinsic_names = jadx_local_names::intrinsic_local_names(root);
         let excluded = parameter_variables
             .iter()
             .copied()
             .flatten()
             .chain(this_variable)
+            .chain(intrinsic_names.keys().copied())
             .collect::<BTreeSet<_>>();
         let model = StructuralNameModel::for_graph(self.types, &graph);
         let mut names =
             ConstrainedNameSolver::new(StructuralNameModel::for_graph(self.types, &graph), 35)
                 .solve(&graph, &roles, parameter_names, &excluded);
+        for (identity, name) in intrinsic_names {
+            names
+                .entry(identity)
+                .or_insert_with(|| KotlinIdentifier::from_hint(&name));
+        }
         fill_remaining_source_names(
             &graph,
             &roles,
@@ -574,10 +558,33 @@ impl<'a> SemanticNameRecovery<'a> {
     }
 }
 
-fn is_register_style_name(name: &str) -> bool {
-    name.strip_prefix('v').is_some_and(|digits| {
-        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
-    })
+fn kotlin_jadx_type_name(ty: &KotlinType) -> Option<String> {
+    match ty {
+        KotlinType::Primitive(primitive) => {
+            jadx_local_names::primitive_local_name(kotlin_primitive(*primitive)).map(str::to_string)
+        }
+        KotlinType::Class(class) => Some(jadx_local_names::class_local_name_from_segments(
+            class.segments.iter().map(|segment| segment.name.as_str()),
+        )),
+        KotlinType::Variable(name) => Some(jadx_local_names::class_local_name(name.as_str())),
+        KotlinType::Array(element) => Some(jadx_local_names::array_local_name(
+            &kotlin_jadx_type_name(element.as_type())?,
+        )),
+    }
+}
+
+fn kotlin_primitive(primitive: KotlinPrimitiveType) -> PrimitiveType {
+    match primitive {
+        KotlinPrimitiveType::Void => PrimitiveType::Void,
+        KotlinPrimitiveType::Boolean => PrimitiveType::Boolean,
+        KotlinPrimitiveType::Byte => PrimitiveType::Byte,
+        KotlinPrimitiveType::Short => PrimitiveType::Short,
+        KotlinPrimitiveType::Char => PrimitiveType::Char,
+        KotlinPrimitiveType::Int => PrimitiveType::Int,
+        KotlinPrimitiveType::Long => PrimitiveType::Long,
+        KotlinPrimitiveType::Float => PrimitiveType::Float,
+        KotlinPrimitiveType::Double => PrimitiveType::Double,
+    }
 }
 
 fn fill_remaining_source_names(

--- a/dexdec/src/analysis/mod.rs
+++ b/dexdec/src/analysis/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod jadx_local_names;
 #[path = "java_backend/mod.rs"]
 pub mod java_backend;
 #[path = "kotlin_backend/mod.rs"]

--- a/dexdec/src/language/java/dex.rs
+++ b/dexdec/src/language/java/dex.rs
@@ -290,10 +290,38 @@ impl OuterInstanceBinding {
     }
 }
 
-fn is_register_style_name(name: &str) -> bool {
-    name.strip_prefix('v').is_some_and(|digits| {
-        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
-    })
+fn jadx_name_for_java_type(ty: &JavaType) -> Option<String> {
+    match ty {
+        JavaType::Primitive(primitive) => {
+            crate::analysis::jadx_local_names::primitive_local_name(match primitive {
+                crate::language::java::JavaPrimitiveType::Void => return None,
+                crate::language::java::JavaPrimitiveType::Boolean => {
+                    crate::ir::PrimitiveType::Boolean
+                }
+                crate::language::java::JavaPrimitiveType::Byte => crate::ir::PrimitiveType::Byte,
+                crate::language::java::JavaPrimitiveType::Short => crate::ir::PrimitiveType::Short,
+                crate::language::java::JavaPrimitiveType::Char => crate::ir::PrimitiveType::Char,
+                crate::language::java::JavaPrimitiveType::Int => crate::ir::PrimitiveType::Int,
+                crate::language::java::JavaPrimitiveType::Long => crate::ir::PrimitiveType::Long,
+                crate::language::java::JavaPrimitiveType::Float => crate::ir::PrimitiveType::Float,
+                crate::language::java::JavaPrimitiveType::Double => {
+                    crate::ir::PrimitiveType::Double
+                }
+            })
+            .map(str::to_string)
+        }
+        JavaType::Class(class) => Some(
+            crate::analysis::jadx_local_names::class_local_name_from_segments(
+                class.segments.iter().map(|segment| segment.name.as_str()),
+            ),
+        ),
+        JavaType::Variable(name) => Some(crate::analysis::jadx_local_names::class_local_name(
+            name.as_str(),
+        )),
+        JavaType::Array(element) => Some(crate::analysis::jadx_local_names::array_local_name(
+            &jadx_name_for_java_type(element)?,
+        )),
+    }
 }
 
 impl DexJavaDialect {
@@ -583,26 +611,7 @@ impl DexJavaDialect {
     }
 
     fn fallback_name_for_type(ty: &JavaType) -> Option<JavaIdentifier> {
-        match ty {
-            JavaType::Class(class) => {
-                let name = &class.segments.last()?.name;
-                let source = name.as_str();
-                (source != "Object" && !is_register_style_name(source)).then(|| {
-                    let mut characters = source.chars();
-                    let Some(first) = characters.next() else {
-                        return JavaIdentifier::from_hint("value");
-                    };
-                    let mut lowered = first.to_lowercase().collect::<String>();
-                    lowered.extend(characters);
-                    JavaIdentifier::from_hint(&lowered)
-                })
-            }
-            JavaType::Array(_) => Some(JavaIdentifier::from_hint("values")),
-            JavaType::Primitive(crate::language::java::JavaPrimitiveType::Boolean) => {
-                Some(JavaIdentifier::from_hint("flag"))
-            }
-            _ => None,
-        }
+        Some(JavaIdentifier::from_hint(&jadx_name_for_java_type(ty)?))
     }
 
     fn arg(&mut self, arg: &SemanticExpression) -> Result<JavaExpr, JavaLoweringError> {

--- a/dexdec/src/language/java/dex.rs
+++ b/dexdec/src/language/java/dex.rs
@@ -290,6 +290,12 @@ impl OuterInstanceBinding {
     }
 }
 
+fn is_register_style_name(name: &str) -> bool {
+    name.strip_prefix('v').is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
 impl DexJavaDialect {
     pub fn new(
         is_static: bool,
@@ -565,11 +571,38 @@ impl DexJavaDialect {
         if let Some(name) = self.names.get(&key) {
             return Ok(name.clone());
         }
-        let name = self
-            .name_scope
-            .claim(JavaIdentifier::from_dex(&format!("v{}", key.raw())));
+        let name = self.name_scope.claim(self.fallback_local_name(register));
         self.names.insert(key, name.clone());
         Ok(name)
+    }
+
+    fn fallback_local_name(&self, register: &RegisterArg) -> JavaIdentifier {
+        self.source_register_type(register)
+            .and_then(Self::fallback_name_for_type)
+            .unwrap_or_else(|| JavaIdentifier::from_hint("value"))
+    }
+
+    fn fallback_name_for_type(ty: &JavaType) -> Option<JavaIdentifier> {
+        match ty {
+            JavaType::Class(class) => {
+                let name = &class.segments.last()?.name;
+                let source = name.as_str();
+                (source != "Object" && !is_register_style_name(source)).then(|| {
+                    let mut characters = source.chars();
+                    let Some(first) = characters.next() else {
+                        return JavaIdentifier::from_hint("value");
+                    };
+                    let mut lowered = first.to_lowercase().collect::<String>();
+                    lowered.extend(characters);
+                    JavaIdentifier::from_hint(&lowered)
+                })
+            }
+            JavaType::Array(_) => Some(JavaIdentifier::from_hint("values")),
+            JavaType::Primitive(crate::language::java::JavaPrimitiveType::Boolean) => {
+                Some(JavaIdentifier::from_hint("flag"))
+            }
+            _ => None,
+        }
     }
 
     fn arg(&mut self, arg: &SemanticExpression) -> Result<JavaExpr, JavaLoweringError> {

--- a/dexdec/src/language/kotlin/dex.rs
+++ b/dexdec/src/language/kotlin/dex.rs
@@ -677,6 +677,12 @@ impl OuterInstanceBinding {
     }
 }
 
+fn is_register_style_name(name: &str) -> bool {
+    name.strip_prefix('v').is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
 impl DexKotlinDialect {
     pub fn new(
         is_static: bool,
@@ -1025,11 +1031,40 @@ impl DexKotlinDialect {
         if let Some(name) = self.names.get(&key) {
             return Ok(name.clone());
         }
-        let name = self
-            .name_scope
-            .claim(KotlinIdentifier::from_dex(&format!("v{}", key.raw())));
+        let name = self.name_scope.claim(self.fallback_local_name(register));
         self.names.insert(key, name.clone());
         Ok(name)
+    }
+
+    fn fallback_local_name(&self, register: &RegisterArg) -> KotlinIdentifier {
+        self.source_register_type(register)
+            .and_then(Self::fallback_name_for_type)
+            .unwrap_or_else(|| KotlinIdentifier::from_hint("value"))
+    }
+
+    fn fallback_name_for_type(ty: &KotlinType) -> Option<KotlinIdentifier> {
+        match ty {
+            KotlinType::Class(class) => {
+                let name = &class.segments.last()?.name;
+                let source = name.as_str();
+                (source != "Any" && source != "Object" && !is_register_style_name(source)).then(
+                    || {
+                        let mut characters = source.chars();
+                        let Some(first) = characters.next() else {
+                            return KotlinIdentifier::from_hint("value");
+                        };
+                        let mut lowered = first.to_lowercase().collect::<String>();
+                        lowered.extend(characters);
+                        KotlinIdentifier::from_hint(&lowered)
+                    },
+                )
+            }
+            KotlinType::Array(_) => Some(KotlinIdentifier::from_hint("values")),
+            KotlinType::Primitive(crate::language::kotlin::KotlinPrimitiveType::Boolean) => {
+                Some(KotlinIdentifier::from_hint("flag"))
+            }
+            _ => None,
+        }
     }
 
     fn arg(&mut self, arg: &SemanticExpression) -> Result<KotlinExpr, KotlinLoweringError> {

--- a/dexdec/src/language/kotlin/dex.rs
+++ b/dexdec/src/language/kotlin/dex.rs
@@ -677,10 +677,48 @@ impl OuterInstanceBinding {
     }
 }
 
-fn is_register_style_name(name: &str) -> bool {
-    name.strip_prefix('v').is_some_and(|digits| {
-        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
-    })
+fn jadx_name_for_kotlin_type(ty: &KotlinType) -> Option<String> {
+    match ty {
+        KotlinType::Primitive(primitive) => {
+            crate::analysis::jadx_local_names::primitive_local_name(match primitive {
+                crate::language::kotlin::KotlinPrimitiveType::Void => return None,
+                crate::language::kotlin::KotlinPrimitiveType::Boolean => {
+                    crate::ir::PrimitiveType::Boolean
+                }
+                crate::language::kotlin::KotlinPrimitiveType::Byte => {
+                    crate::ir::PrimitiveType::Byte
+                }
+                crate::language::kotlin::KotlinPrimitiveType::Short => {
+                    crate::ir::PrimitiveType::Short
+                }
+                crate::language::kotlin::KotlinPrimitiveType::Char => {
+                    crate::ir::PrimitiveType::Char
+                }
+                crate::language::kotlin::KotlinPrimitiveType::Int => crate::ir::PrimitiveType::Int,
+                crate::language::kotlin::KotlinPrimitiveType::Long => {
+                    crate::ir::PrimitiveType::Long
+                }
+                crate::language::kotlin::KotlinPrimitiveType::Float => {
+                    crate::ir::PrimitiveType::Float
+                }
+                crate::language::kotlin::KotlinPrimitiveType::Double => {
+                    crate::ir::PrimitiveType::Double
+                }
+            })
+            .map(str::to_string)
+        }
+        KotlinType::Class(class) => Some(
+            crate::analysis::jadx_local_names::class_local_name_from_segments(
+                class.segments.iter().map(|segment| segment.name.as_str()),
+            ),
+        ),
+        KotlinType::Variable(name) => Some(crate::analysis::jadx_local_names::class_local_name(
+            name.as_str(),
+        )),
+        KotlinType::Array(element) => Some(crate::analysis::jadx_local_names::array_local_name(
+            &jadx_name_for_kotlin_type(element.as_type())?,
+        )),
+    }
 }
 
 impl DexKotlinDialect {
@@ -1043,28 +1081,7 @@ impl DexKotlinDialect {
     }
 
     fn fallback_name_for_type(ty: &KotlinType) -> Option<KotlinIdentifier> {
-        match ty {
-            KotlinType::Class(class) => {
-                let name = &class.segments.last()?.name;
-                let source = name.as_str();
-                (source != "Any" && source != "Object" && !is_register_style_name(source)).then(
-                    || {
-                        let mut characters = source.chars();
-                        let Some(first) = characters.next() else {
-                            return KotlinIdentifier::from_hint("value");
-                        };
-                        let mut lowered = first.to_lowercase().collect::<String>();
-                        lowered.extend(characters);
-                        KotlinIdentifier::from_hint(&lowered)
-                    },
-                )
-            }
-            KotlinType::Array(_) => Some(KotlinIdentifier::from_hint("values")),
-            KotlinType::Primitive(crate::language::kotlin::KotlinPrimitiveType::Boolean) => {
-                Some(KotlinIdentifier::from_hint("flag"))
-            }
-            _ => None,
-        }
+        Some(KotlinIdentifier::from_hint(&jadx_name_for_kotlin_type(ty)?))
     }
 
     fn arg(&mut self, arg: &SemanticExpression) -> Result<KotlinExpr, KotlinLoweringError> {

--- a/dexdec/tests/testcases/expected/BranchMaze.kt.expected
+++ b/dexdec/tests/testcases/expected/BranchMaze.kt.expected
@@ -1,19 +1,19 @@
 public open class BranchMaze {
     companion object {
-        public fun classify(p0: Int, p1: Int, p2: Int): Int {
+        public fun classify(i: Int, i2: Int, i3: Int): Int {
             var result: Int
-            if (p0 > 0 && (p1 < 0 || p2 == 0)) {
+            if (i > 0 && (i2 < 0 || i3 == 0)) {
                 result = 1
             } else {
                 result = 2
-                if (p0 != 0 && (p1 <= 0 || p2 <= 0)) {
+                if (i != 0 && (i2 <= 0 || i3 <= 0)) {
                     result = 3
                 }
             }
             if (result != 2) {
                 return result
             }
-            if (p2 >= 0 && p0 >= p1) {
+            if (i3 >= 0 && i >= i2) {
                 return result
             }
             return result + 10

--- a/dexdec/tests/testcases/expected/BreakContinue.kt.expected
+++ b/dexdec/tests/testcases/expected/BreakContinue.kt.expected
@@ -1,9 +1,9 @@
 public open class BreakContinue {
     companion object {
-        public fun findFirst(values: IntArray, p1: Int): Int {
+        public fun findFirst(iArr: IntArray, i: Int): Int {
             var index: Int = 0
-            while (index < values.size) {
-                if (values[index] == p1) {
+            while (index < iArr.size) {
+                if (iArr[index] == i) {
                     return index
                 }
                 index++
@@ -12,35 +12,35 @@ public open class BreakContinue {
             return index
         }
 
-        public fun findPair(values: IntArray, p1: Int): Boolean {
+        public fun findPair(iArr: IntArray, i: Int): Boolean {
             var index: Int = 0
-            while (index < values.size) {
-                val value: Int = index + 1
-                var index2: Int = value
-                while (index2 < values.size) {
-                    if (values[index] + values[index2] == p1) {
+            while (index < iArr.size) {
+                val i2: Int = index + 1
+                var index2: Int = i2
+                while (index2 < iArr.size) {
+                    if (iArr[index] + iArr[index2] == i) {
                         return true
                     }
                     index2++
                 }
-                index = value
+                index = i2
             }
             return false
         }
 
-        public fun sumPositive(values: IntArray): Int {
+        public fun sumPositive(iArr: IntArray): Int {
             var index: Int = 0
-            var result: Int = 0
-            while (index < values.size) {
-                if (values[index] > 0) {
-                    val value: Int = result + values[index]
+            var i: Int = 0
+            while (index < iArr.size) {
+                if (iArr[index] > 0) {
+                    val i2: Int = i + iArr[index]
                     index++
-                    result = value
+                    i = i2
                 } else {
                     index++
                 }
             }
-            return result
+            return i
         }
     }
 }

--- a/dexdec/tests/testcases/expected/BreakContinue.kt.expected
+++ b/dexdec/tests/testcases/expected/BreakContinue.kt.expected
@@ -15,15 +15,15 @@ public open class BreakContinue {
         public fun findPair(values: IntArray, p1: Int): Boolean {
             var index: Int = 0
             while (index < values.size) {
-                val v3: Int = index + 1
-                var index2: Int = v3
+                val value: Int = index + 1
+                var index2: Int = value
                 while (index2 < values.size) {
                     if (values[index] + values[index2] == p1) {
                         return true
                     }
                     index2++
                 }
-                index = v3
+                index = value
             }
             return false
         }
@@ -33,9 +33,9 @@ public open class BreakContinue {
             var result: Int = 0
             while (index < values.size) {
                 if (values[index] > 0) {
-                    val v6: Int = result + values[index]
+                    val value: Int = result + values[index]
                     index++
-                    result = v6
+                    result = value
                 } else {
                     index++
                 }

--- a/dexdec/tests/testcases/expected/ComplexControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/ComplexControlFlow.kt.expected
@@ -1,32 +1,32 @@
 public open class ComplexControlFlow {
     companion object {
-        public fun doWhileClamp(p0: Int): Int {
-            var p0: Int = p0
+        public fun doWhileClamp(i: Int): Int {
+            var i: Int = i
             while (true) {
-                if (p0 < 0) {
-                    p0 = -p0
+                if (i < 0) {
+                    i = -i
                 }
-                if (p0 > 10) {
+                if (i > 10) {
                     return 10
                 }
-                val value: Int = p0 + 1
-                if (value >= 5) {
-                    return value
+                val i2: Int = i + 1
+                if (i2 >= 5) {
+                    return i2
                 }
-                p0 = value
+                i = i2
             }
         }
 
-        public fun findInMatrix(valueses: Array<IntArray?>, p1: Int): Int {
+        public fun findInMatrix(iArrArr: Array<IntArray?>, i: Int): Int {
             var index2: Int = 0
-            while (index2 < valueses.size) {
-                val values: IntArray? = valueses[index2]
+            while (index2 < iArrArr.size) {
+                val iArr: IntArray? = iArrArr[index2]
                 var index: Int = 0
-                while (index < values!!.size) {
-                    if (values[index] == p1) {
+                while (index < iArr!!.size) {
+                    if (iArr[index] == i) {
                         return index2 * 1000 + index
                     }
-                    if (values[index] != -1) {
+                    if (iArr[index] != -1) {
                         index++
                         continue
                     }
@@ -37,14 +37,14 @@ public open class ComplexControlFlow {
             return -1
         }
 
-        public fun sumUntil(values: IntArray, p1: Int): Int {
+        public fun sumUntil(iArr: IntArray, i: Int): Int {
             var index: Int = 0
             var total: Int = 0
-            while (index < values.size) {
-                val step: Int = values[index]
+            while (index < iArr.size) {
+                val step: Int = iArr[index]
                 if (step >= 0) {
                     total += step
-                    if (total > p1) {
+                    if (total > i) {
                         return total
                     }
                 }
@@ -53,11 +53,11 @@ public open class ComplexControlFlow {
             return total
         }
 
-        public fun whileSwitch(p0: Int): Int {
-            var value: Int = 0
+        public fun whileSwitch(i: Int): Int {
+            var i2: Int = 0
             var total: Int = 0
-            while (value < 5) {
-                when (p0 + value) {
+            while (i2 < 5) {
+                when (i + i2) {
                     0 -> {
                         total++
                     }
@@ -75,9 +75,9 @@ public open class ComplexControlFlow {
                     if (total > 10) {
                         return total
                     }
-                    value++
+                    i2++
                 } else {
-                    value++
+                    i2++
                 }
             }
             return total

--- a/dexdec/tests/testcases/expected/ComplexControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/ComplexControlFlow.kt.expected
@@ -9,11 +9,11 @@ public open class ComplexControlFlow {
                 if (p0 > 10) {
                     return 10
                 }
-                val v2: Int = p0 + 1
-                if (v2 >= 5) {
-                    return v2
+                val value: Int = p0 + 1
+                if (value >= 5) {
+                    return value
                 }
-                p0 = v2
+                p0 = value
             }
         }
 
@@ -54,10 +54,10 @@ public open class ComplexControlFlow {
         }
 
         public fun whileSwitch(p0: Int): Int {
-            var v1: Int = 0
+            var value: Int = 0
             var total: Int = 0
-            while (v1 < 5) {
-                when (p0 + v1) {
+            while (value < 5) {
+                when (p0 + value) {
                     0 -> {
                         total++
                     }
@@ -75,9 +75,9 @@ public open class ComplexControlFlow {
                     if (total > 10) {
                         return total
                     }
-                    v1++
+                    value++
                 } else {
-                    v1++
+                    value++
                 }
             }
             return total

--- a/dexdec/tests/testcases/expected/DeepNesting.kt.expected
+++ b/dexdec/tests/testcases/expected/DeepNesting.kt.expected
@@ -1,28 +1,28 @@
 public open class DeepNesting {
     companion object {
-        public fun classify(p0: Int, p1: Int, p2: Int): Int {
-            if (p0 <= 0) {
-                if (p1 <= 0) {
+        public fun classify(i: Int, i2: Int, i3: Int): Int {
+            if (i <= 0) {
+                if (i2 <= 0) {
                     return 6
                 }
                 return 5
             }
-            if (p1 <= 0) {
-                if (p2 <= 0) {
+            if (i2 <= 0) {
+                if (i3 <= 0) {
                     return 4
                 }
                 return 3
             }
-            if (p2 <= 0) {
+            if (i3 <= 0) {
                 return 2
             }
             return 1
         }
 
-        public fun conditionalSum(p0: Int): Int {
+        public fun conditionalSum(i: Int): Int {
             var step: Int = 0
             var total: Int = 0
-            while (step < p0) {
+            while (step < i) {
                 if (step % 2 != 0) {
                     total -= step
                 } else {
@@ -33,16 +33,16 @@ public open class DeepNesting {
             return total
         }
 
-        public fun matrixSum(p0: Int, p1: Int): Int {
-            var value: Int = 0
+        public fun matrixSum(i: Int, i2: Int): Int {
+            var i3: Int = 0
             var result: Int = 0
-            while (value < p0) {
-                var value2: Int = 0
-                while (value2 < p1) {
-                    result = result + value * p1 + value2
-                    value2++
+            while (i3 < i) {
+                var i4: Int = 0
+                while (i4 < i2) {
+                    result = result + i3 * i2 + i4
+                    i4++
                 }
-                value++
+                i3++
             }
             return result
         }

--- a/dexdec/tests/testcases/expected/DeepNesting.kt.expected
+++ b/dexdec/tests/testcases/expected/DeepNesting.kt.expected
@@ -34,15 +34,15 @@ public open class DeepNesting {
         }
 
         public fun matrixSum(p0: Int, p1: Int): Int {
-            var v2: Int = 0
+            var value: Int = 0
             var result: Int = 0
-            while (v2 < p0) {
-                var v9: Int = 0
-                while (v9 < p1) {
-                    result = result + v2 * p1 + v9
-                    v9++
+            while (value < p0) {
+                var value2: Int = 0
+                while (value2 < p1) {
+                    result = result + value * p1 + value2
+                    value2++
                 }
-                v2++
+                value++
             }
             return result
         }

--- a/dexdec/tests/testcases/expected/DoWhile.kt.expected
+++ b/dexdec/tests/testcases/expected/DoWhile.kt.expected
@@ -1,12 +1,12 @@
 public open class DoWhile {
     companion object {
-        public fun countDigits(p0: Int): Int {
-            var p0: Int = p0
+        public fun countDigits(i: Int): Int {
+            var i: Int = i
             var count: Int = 0
             do {
                 count++
-                p0 /= 10
-            } while (p0 > 0)
+                i /= 10
+            } while (i > 0)
             return count
         }
     }

--- a/dexdec/tests/testcases/expected/ExceptionControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/ExceptionControlFlow.kt.expected
@@ -1,16 +1,16 @@
 public open class ExceptionControlFlow {
     companion object {
-        public fun finallySideEffect(values: IntArray?): Int {
+        public fun finallySideEffect(iArr: IntArray?): Int {
             try {
-                values!![0] = 1
-                return values[0]
+                iArr!![0] = 1
+                return iArr[0]
             } finally {
-                values!![0] = values!![0] + 1
+                iArr!![0] = iArr!![0] + 1
             }
         }
 
-        public fun nestedTry(p0: Int): Int {
-            if (p0 >= 0) {
+        public fun nestedTry(i: Int): Int {
+            if (i >= 0) {
                 return 1
             }
             try {
@@ -22,9 +22,9 @@ public open class ExceptionControlFlow {
             }
         }
 
-        public fun nestedTryFinally(p0: Int): Int {
+        public fun nestedTryFinally(i: Int): Int {
             var result: Int = 0
-            if (p0 >= 0) {
+            if (i >= 0) {
                 result = 11
                 return result
             }
@@ -40,12 +40,12 @@ public open class ExceptionControlFlow {
             }
         }
 
-        public fun tryCatchFinally(p0: Int, p1: Int): Int {
+        public fun tryCatchFinally(i: Int, i2: Int): Int {
             try {
-                if (p1 == 0) {
+                if (i2 == 0) {
                     throw ArithmeticException()
                 }
-                return p0 / p1
+                return i / i2
             } catch (exception2: ArithmeticException) {
                 return -1
             } catch (exception: Throwable) {
@@ -53,15 +53,15 @@ public open class ExceptionControlFlow {
             }
         }
 
-        public fun tryCatchFinallyWithContinue(values: IntArray?): Int {
+        public fun tryCatchFinallyWithContinue(iArr: IntArray?): Int {
             var index: Int = 0
             var total: Int = 0
-            while (index < values!!.size) {
+            while (index < iArr!!.size) {
                 var condition: Boolean = false
-                var value: Int = 0
+                var i: Int = 0
                 try {
-                    if (values[index] != 0) {
-                        value = 100 / values[index]
+                    if (iArr[index] != 0) {
+                        i = 100 / iArr[index]
                     } else {
                         total += 2
                         index++
@@ -75,7 +75,7 @@ public open class ExceptionControlFlow {
                     throw exception
                 }
                 if (!condition) {
-                    val step: Int = total + value
+                    val step: Int = total + i
                     if (step > 50) {
                         return step
                     }
@@ -86,13 +86,13 @@ public open class ExceptionControlFlow {
             return total
         }
 
-        public fun tryInLoop(values: IntArray?): Int {
+        public fun tryInLoop(iArr: IntArray?): Int {
             var index: Int = 0
             var total: Int = 0
-            while (index < values!!.size) {
+            while (index < iArr!!.size) {
                 try {
-                    if (values[index] != 0) {
-                        total += 10 / values[index]
+                    if (iArr[index] != 0) {
+                        total += 10 / iArr[index]
                     }
                     index++
                 } catch (exception: ArithmeticException) {

--- a/dexdec/tests/testcases/expected/ExceptionControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/ExceptionControlFlow.kt.expected
@@ -58,10 +58,10 @@ public open class ExceptionControlFlow {
             var total: Int = 0
             while (index < values!!.size) {
                 var condition: Boolean = false
-                var v12: Int = 0
+                var value: Int = 0
                 try {
                     if (values[index] != 0) {
-                        v12 = 100 / values[index]
+                        value = 100 / values[index]
                     } else {
                         total += 2
                         index++
@@ -75,7 +75,7 @@ public open class ExceptionControlFlow {
                     throw exception
                 }
                 if (!condition) {
-                    val step: Int = total + v12
+                    val step: Int = total + value
                     if (step > 50) {
                         return step
                     }

--- a/dexdec/tests/testcases/expected/ExceptionControlFlowAdvanced.kt.expected
+++ b/dexdec/tests/testcases/expected/ExceptionControlFlowAdvanced.kt.expected
@@ -24,18 +24,18 @@ public open class ExceptionControlFlowAdvanced {
 
         public fun multiCatchAndFinally(values: IntArray?): Int {
             var index: Int = 0
-            var v4: Int = 0
+            var value: Int = 0
             var result: Int
             try {
                 while (index < values!!.size) {
                     if (values[index] < 0) {
                         throw IllegalArgumentException()
                     }
-                    val v5: Int = v4 + 10 / values[index]
+                    val value2: Int = value + 10 / values[index]
                     index++
-                    v4 = v5
+                    value = value2
                 }
-                result = v4 + 3
+                result = value + 3
                 return result
             } catch (exception3: IllegalArgumentException) {
                 result = 1

--- a/dexdec/tests/testcases/expected/ExceptionControlFlowAdvanced.kt.expected
+++ b/dexdec/tests/testcases/expected/ExceptionControlFlowAdvanced.kt.expected
@@ -1,16 +1,16 @@
 public open class ExceptionControlFlowAdvanced {
     companion object {
-        public fun finallyWithBreakContinue(values: IntArray?): Int {
+        public fun finallyWithBreakContinue(iArr: IntArray?): Int {
             var index: Int = 0
             var count: Int = 0
-            while (index < values!!.size) {
+            while (index < iArr!!.size) {
                 try {
-                    if (values[index] != 0) {
-                        if (values[index] < 0) {
+                    if (iArr[index] != 0) {
+                        if (iArr[index] < 0) {
                             count++
                             return count
                         }
-                        count = count + values[index] + 1
+                        count = count + iArr[index] + 1
                     } else {
                         count++
                     }
@@ -22,20 +22,20 @@ public open class ExceptionControlFlowAdvanced {
             return count
         }
 
-        public fun multiCatchAndFinally(values: IntArray?): Int {
+        public fun multiCatchAndFinally(iArr: IntArray?): Int {
             var index: Int = 0
-            var value: Int = 0
+            var i: Int = 0
             var result: Int
             try {
-                while (index < values!!.size) {
-                    if (values[index] < 0) {
+                while (index < iArr!!.size) {
+                    if (iArr[index] < 0) {
                         throw IllegalArgumentException()
                     }
-                    val value2: Int = value + 10 / values[index]
+                    val i2: Int = i + 10 / iArr[index]
                     index++
-                    value = value2
+                    i = i2
                 }
-                result = value + 3
+                result = i + 3
                 return result
             } catch (exception3: IllegalArgumentException) {
                 result = 1
@@ -48,9 +48,9 @@ public open class ExceptionControlFlowAdvanced {
             }
         }
 
-        public fun nestedTryInCatch(p0: Int): Int {
+        public fun nestedTryInCatch(i: Int): Int {
             var result: Int = 0
-            if (p0 != 0) {
+            if (i != 0) {
                 result = 1
                 return result
             }
@@ -58,7 +58,7 @@ public open class ExceptionControlFlowAdvanced {
                 throw RuntimeException()
             } catch (exception: RuntimeException) {
                 try {
-                    if (p0 < 0) {
+                    if (i < 0) {
                         result = 3
                         throw IllegalStateException()
                     }

--- a/dexdec/tests/testcases/expected/Finally.kt.expected
+++ b/dexdec/tests/testcases/expected/Finally.kt.expected
@@ -2,9 +2,9 @@ public open class Finally {
     companion object {
         private var counter: Int = 0
 
-        public fun test(p0: Int): Int {
+        public fun test(i: Int): Int {
             var counter: Int
-            if (p0 == 0) {
+            if (i == 0) {
                 try {
                     throw RuntimeException("zero")
                 } catch (exception: RuntimeException) {
@@ -15,7 +15,7 @@ public open class Finally {
                 }
             }
             try {
-                return 100 / p0
+                return 100 / i
             } catch (exception: RuntimeException) {
                 return -1
             } finally {

--- a/dexdec/tests/testcases/expected/ForLoop.kt.expected
+++ b/dexdec/tests/testcases/expected/ForLoop.kt.expected
@@ -1,12 +1,12 @@
 public open class ForLoop {
     companion object {
         public fun factorial(p0: Int): Int {
-            var v1: Int = 1
+            var value: Int = 1
             var result: Int = 1
-            while (v1 <= p0) {
-                val v5: Int = result * v1
-                v1++
-                result = v5
+            while (value <= p0) {
+                val value2: Int = result * value
+                value++
+                result = value2
             }
             return result
         }

--- a/dexdec/tests/testcases/expected/ForLoop.kt.expected
+++ b/dexdec/tests/testcases/expected/ForLoop.kt.expected
@@ -1,12 +1,12 @@
 public open class ForLoop {
     companion object {
-        public fun factorial(p0: Int): Int {
-            var value: Int = 1
+        public fun factorial(i: Int): Int {
+            var i2: Int = 1
             var result: Int = 1
-            while (value <= p0) {
-                val value2: Int = result * value
-                value++
-                result = value2
+            while (i2 <= i) {
+                val i3: Int = result * i2
+                i2++
+                result = i3
             }
             return result
         }

--- a/dexdec/tests/testcases/expected/HardcoreControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/HardcoreControlFlow.kt.expected
@@ -27,62 +27,62 @@ public open class HardcoreControlFlow {
     }
 
     public open fun exceptionSpaghetti(p0: Int, p1: Int): Int {
-        var v3: Int = 0
-        var v8: Int = 0
+        var value2: Int = 0
+        var value4: Int = 0
         if (p0 <= 0) {
             try {
-                v8 = -2
+                value4 = -2
                 throw IllegalArgumentException()
             } catch (exception5: IllegalArgumentException) {
-                v8 = v3 - 100
-                if (v8 <= 0) {
-                    return v8
+                value4 = value2 - 100
+                if (value4 <= 0) {
+                    return value4
                 }
-                return v8 * 2
+                return value4 * 2
             } catch (exception4: ArithmeticException) {
-                return v8
+                return value4
             } catch (exception3: Throwable) {
-                if (v3 <= 0) {
+                if (value2 <= 0) {
                     throw exception3
                 }
-                return v3 * 2
+                return value2 * 2
             }
         }
-        val v2: Int = 0
+        val value: Int = 0
         try {
-            v8 = -2
-            val v7: Int = p0 / p1
-            if (v7 <= 10) {
-                v8 = v7 + 100
-                if (v8 <= 0) {
-                    return v8
+            value4 = -2
+            val value3: Int = p0 / p1
+            if (value3 <= 10) {
+                value4 = value3 + 100
+                if (value4 <= 0) {
+                    return value4
                 }
-                return v8 * 2
+                return value4 * 2
             }
-            val v19: Int = v7 + 100
-            if (v19 <= 0) {
-                return v7
+            val value5: Int = value3 + 100
+            if (value5 <= 0) {
+                return value3
             }
-            return v19 * 2
+            return value5 * 2
         } catch (exception2: ArithmeticException) {
             throw exception2
         } catch (exception: Throwable) {
-            v3 = v2 + 100
+            value2 = value + 100
             try {
                 throw exception
             } catch (exception5: IllegalArgumentException) {
-                v8 = v3 - 100
-                if (v8 <= 0) {
-                    return v8
+                value4 = value2 - 100
+                if (value4 <= 0) {
+                    return value4
                 }
-                return v8 * 2
+                return value4 * 2
             } catch (exception4: ArithmeticException) {
-                return v8
+                return value4
             } catch (exception3: Throwable) {
-                if (v3 <= 0) {
+                if (value2 <= 0) {
                     throw exception3
                 }
-                return v3 * 2
+                return value2 * 2
             }
         }
     }

--- a/dexdec/tests/testcases/expected/HardcoreControlFlow.kt.expected
+++ b/dexdec/tests/testcases/expected/HardcoreControlFlow.kt.expected
@@ -1,113 +1,113 @@
 public open class HardcoreControlFlow {
-    private fun check(p0: Int): Boolean {
-        if (p0 <= 0) {
+    private fun check(i: Int): Boolean {
+        if (i <= 0) {
             return false
         }
         return true
     }
 
-    private fun modify(p0: Int): Boolean {
-        if (p0 % 2 != 0) {
+    private fun modify(i: Int): Boolean {
+        if (i % 2 != 0) {
             return false
         }
         return true
     }
 
-    public open fun complexLogic(p0: Int, p1: Int): Boolean {
-        if (this.check(p0)) {
+    public open fun complexLogic(i: Int, i2: Int): Boolean {
+        if (this.check(i)) {
             return true
         }
-        if (this.modify(p0) && this.check(p1)) {
+        if (this.modify(i) && this.check(i2)) {
             return true
         }
-        if (this.modify(p1)) {
+        if (this.modify(i2)) {
             return true
         }
         return false
     }
 
-    public open fun exceptionSpaghetti(p0: Int, p1: Int): Int {
-        var value2: Int = 0
-        var value4: Int = 0
-        if (p0 <= 0) {
+    public open fun exceptionSpaghetti(i: Int, i2: Int): Int {
+        var i4: Int = 0
+        var i6: Int = 0
+        if (i <= 0) {
             try {
-                value4 = -2
+                i6 = -2
                 throw IllegalArgumentException()
             } catch (exception5: IllegalArgumentException) {
-                value4 = value2 - 100
-                if (value4 <= 0) {
-                    return value4
+                i6 = i4 - 100
+                if (i6 <= 0) {
+                    return i6
                 }
-                return value4 * 2
+                return i6 * 2
             } catch (exception4: ArithmeticException) {
-                return value4
+                return i6
             } catch (exception3: Throwable) {
-                if (value2 <= 0) {
+                if (i4 <= 0) {
                     throw exception3
                 }
-                return value2 * 2
+                return i4 * 2
             }
         }
-        val value: Int = 0
+        val i3: Int = 0
         try {
-            value4 = -2
-            val value3: Int = p0 / p1
-            if (value3 <= 10) {
-                value4 = value3 + 100
-                if (value4 <= 0) {
-                    return value4
+            i6 = -2
+            val i5: Int = i / i2
+            if (i5 <= 10) {
+                i6 = i5 + 100
+                if (i6 <= 0) {
+                    return i6
                 }
-                return value4 * 2
+                return i6 * 2
             }
-            val value5: Int = value3 + 100
-            if (value5 <= 0) {
-                return value3
+            val i7: Int = i5 + 100
+            if (i7 <= 0) {
+                return i5
             }
-            return value5 * 2
+            return i7 * 2
         } catch (exception2: ArithmeticException) {
             throw exception2
         } catch (exception: Throwable) {
-            value2 = value + 100
+            i4 = i3 + 100
             try {
                 throw exception
             } catch (exception5: IllegalArgumentException) {
-                value4 = value2 - 100
-                if (value4 <= 0) {
-                    return value4
+                i6 = i4 - 100
+                if (i6 <= 0) {
+                    return i6
                 }
-                return value4 * 2
+                return i6 * 2
             } catch (exception4: ArithmeticException) {
-                return value4
+                return i6
             } catch (exception3: Throwable) {
-                if (value2 <= 0) {
+                if (i4 <= 0) {
                     throw exception3
                 }
-                return value2 * 2
+                return i4 * 2
             }
         }
     }
 
-    public open fun labeledBreaks(valueses: Array<IntArray?>): Int {
+    public open fun labeledBreaks(iArrArr: Array<IntArray?>): Int {
         var index: Int = 0
         var total: Int = 0
-        while (index < valueses.size) {
-            if (valueses[index] !== null) {
+        while (index < iArrArr.size) {
+            if (iArrArr[index] !== null) {
                 var index2: Int = 0
                 var condition: Boolean = false
-                while (index2 < valueses[index]!!.size) {
-                    val element: Int = valueses[index]!![index2]
-                    if (element == -1) {
+                while (index2 < iArrArr[index]!!.size) {
+                    val i: Int = iArrArr[index]!![index2]
+                    if (i == -1) {
                         return total
                     }
-                    if (element == -2) {
+                    if (i == -2) {
                         break
                     }
-                    if (element == -3) {
+                    if (i == -3) {
                         break
                     }
-                    if (element > 100) {
+                    if (i > 100) {
                         var step: Int = 0
-                        while (step < element) {
+                        while (step < i) {
                             if (step * index2 > 1000) {
                                 total += step
                                 condition = true
@@ -119,7 +119,7 @@ public open class HardcoreControlFlow {
                             break
                         }
                     }
-                    total += element
+                    total += i
                     index2++
                 }
             }
@@ -128,12 +128,12 @@ public open class HardcoreControlFlow {
         return total
     }
 
-    public open fun stateMachine(values: IntArray): Int {
+    public open fun stateMachine(iArr: IntArray): Int {
         var index: Int = 0
         var total: Int = 0
         var selector: Int = 0
-        while (index < values.size) {
-            val step: Int = values[index]
+        while (index < iArr.size) {
+            val step: Int = iArr[index]
             when (selector) {
                 0 -> {
                     if (step > 0) {

--- a/dexdec/tests/testcases/expected/MultiCatch.kt.expected
+++ b/dexdec/tests/testcases/expected/MultiCatch.kt.expected
@@ -1,11 +1,11 @@
 public open class MultiCatch {
     companion object {
-        public fun process(p0: Int, p1: Int): Int {
+        public fun process(i: Int, i2: Int): Int {
             try {
-                if (p0 < 0) {
+                if (i < 0) {
                     throw IllegalArgumentException("negative a")
                 }
-                return p0 / p1
+                return i / i2
             } catch (exception2: IllegalArgumentException) {
                 return -1
             } catch (exception: ArithmeticException) {

--- a/dexdec/tests/testcases/expected/MultiReturn.kt.expected
+++ b/dexdec/tests/testcases/expected/MultiReturn.kt.expected
@@ -1,26 +1,26 @@
 public open class MultiReturn {
     companion object {
-        public fun abs(p0: Int): Int {
-            if (p0 < 0) {
-                return -p0
+        public fun abs(i: Int): Int {
+            if (i < 0) {
+                return -i
             }
-            return p0
+            return i
         }
 
-        public fun earlyReturn(p0: Int): Int {
-            if (p0 < 0) {
+        public fun earlyReturn(i: Int): Int {
+            if (i < 0) {
                 return -1
             }
-            if (p0 != 0) {
+            if (i != 0) {
                 return 1
             }
             return 0
         }
 
-        public fun findValue(values: IntArray, p1: Int): Int {
+        public fun findValue(iArr: IntArray, i: Int): Int {
             var index: Int = 0
-            while (index < values.size) {
-                if (values[index] == p1) {
+            while (index < iArr.size) {
+                if (iArr[index] == i) {
                     return index
                 }
                 index++
@@ -28,17 +28,17 @@ public open class MultiReturn {
             return -1
         }
 
-        public fun grade(p0: Int): String {
-            if (p0 >= 90) {
+        public fun grade(i: Int): String {
+            if (i >= 90) {
                 return "A"
             }
-            if (p0 >= 80) {
+            if (i >= 80) {
                 return "B"
             }
-            if (p0 >= 70) {
+            if (i >= 70) {
                 return "C"
             }
-            if (p0 < 60) {
+            if (i < 60) {
                 return "F"
             }
             return "D"

--- a/dexdec/tests/testcases/expected/NestedIf.kt.expected
+++ b/dexdec/tests/testcases/expected/NestedIf.kt.expected
@@ -1,13 +1,13 @@
 public open class NestedIf {
     companion object {
-        public fun compare(p0: Int, p1: Int): Int {
-            if (p0 <= p1) {
-                if (p1 <= 100) {
+        public fun compare(i: Int, i2: Int): Int {
+            if (i <= i2) {
+                if (i2 <= 100) {
                     return -1
                 }
                 return -2
             }
-            if (p0 <= 100) {
+            if (i <= 100) {
                 return 1
             }
             return 2

--- a/dexdec/tests/testcases/expected/NestedLoopBranches.kt.expected
+++ b/dexdec/tests/testcases/expected/NestedLoopBranches.kt.expected
@@ -1,15 +1,15 @@
 public open class NestedLoopBranches {
     companion object {
-        public fun compute(values: IntArray, valueses: Array<IntArray?>, p2: Int): Int {
+        public fun compute(iArr: IntArray, iArrArr: Array<IntArray?>, i: Int): Int {
             var index: Int = 0
             var total: Int = 0
-            while (index < values.size) {
-                if (values[index] >= 0) {
-                    val values2: IntArray? = valueses[index]
+            while (index < iArr.size) {
+                if (iArr[index] >= 0) {
+                    val iArr2: IntArray? = iArrArr[index]
                     var index2: Int = 0
-                    while (index2 < values2!!.size) {
-                        val step: Int = values2[index2]
-                        if (step == p2) {
+                    while (index2 < iArr2!!.size) {
+                        val step: Int = iArr2[index2]
+                        if (step == i) {
                             return total + step
                         }
                         if (step % 2 != 0) {

--- a/dexdec/tests/testcases/expected/ShortCircuit.kt.expected
+++ b/dexdec/tests/testcases/expected/ShortCircuit.kt.expected
@@ -1,43 +1,43 @@
 public open class ShortCircuit {
     companion object {
-        public fun checkAnd(p0: Int, p1: Int): Boolean {
-            if (p0 <= 0) {
+        public fun checkAnd(i: Int, i2: Int): Boolean {
+            if (i <= 0) {
                 return false
             }
-            if (p1 <= 0) {
-                return false
-            }
-            return true
-        }
-
-        public fun checkComplex(p0: Int, p1: Int, p2: Int, p3: Int): Boolean {
-            if (p1 > 0 && p0 > 0) {
-                return true
-            }
-            if (p2 <= 0) {
-                return false
-            }
-            if (p3 <= 0) {
+            if (i2 <= 0) {
                 return false
             }
             return true
         }
 
-        public fun checkNegated(p0: Int, p1: Int): Boolean {
-            if (p0 <= 0) {
+        public fun checkComplex(i: Int, i2: Int, i3: Int, i4: Int): Boolean {
+            if (i2 > 0 && i > 0) {
                 return true
             }
-            if (p1 > 0) {
+            if (i3 <= 0) {
+                return false
+            }
+            if (i4 <= 0) {
                 return false
             }
             return true
         }
 
-        public fun checkOr(p0: Int, p1: Int): Boolean {
-            if (p0 > 0) {
+        public fun checkNegated(i: Int, i2: Int): Boolean {
+            if (i <= 0) {
                 return true
             }
-            if (p1 <= 0) {
+            if (i2 > 0) {
+                return false
+            }
+            return true
+        }
+
+        public fun checkOr(i: Int, i2: Int): Boolean {
+            if (i > 0) {
+                return true
+            }
+            if (i2 <= 0) {
                 return false
             }
             return true

--- a/dexdec/tests/testcases/expected/SimpleIf.kt.expected
+++ b/dexdec/tests/testcases/expected/SimpleIf.kt.expected
@@ -1,7 +1,7 @@
 public open class SimpleIf {
     companion object {
-        public fun test(p0: Int): Int {
-            if (p0 <= 0) {
+        public fun test(i: Int): Int {
+            if (i <= 0) {
                 return -1
             }
             return 1

--- a/dexdec/tests/testcases/expected/SimpleLoop.kt.expected
+++ b/dexdec/tests/testcases/expected/SimpleLoop.kt.expected
@@ -1,12 +1,12 @@
 public open class SimpleLoop {
     companion object {
-        public fun sum(p0: Int): Int {
-            var value: Int = 0
+        public fun sum(i: Int): Int {
+            var i2: Int = 0
             var result: Int = 0
-            while (value < p0) {
-                val value2: Int = result + value
-                value++
-                result = value2
+            while (i2 < i) {
+                val i3: Int = result + i2
+                i2++
+                result = i3
             }
             return result
         }

--- a/dexdec/tests/testcases/expected/SimpleLoop.kt.expected
+++ b/dexdec/tests/testcases/expected/SimpleLoop.kt.expected
@@ -1,12 +1,12 @@
 public open class SimpleLoop {
     companion object {
         public fun sum(p0: Int): Int {
-            var v1: Int = 0
+            var value: Int = 0
             var result: Int = 0
-            while (v1 < p0) {
-                val v5: Int = result + v1
-                v1++
-                result = v5
+            while (value < p0) {
+                val value2: Int = result + value
+                value++
+                result = value2
             }
             return result
         }

--- a/dexdec/tests/testcases/expected/Switch.kt.expected
+++ b/dexdec/tests/testcases/expected/Switch.kt.expected
@@ -1,7 +1,7 @@
 public open class Switch {
     companion object {
-        public fun dayName(p0: Int): String {
-            when (p0) {
+        public fun dayName(i: Int): String {
+            when (i) {
                 1 -> {
                     return "Monday"
                 }

--- a/dexdec/tests/testcases/expected/Synchronized.kt.expected
+++ b/dexdec/tests/testcases/expected/Synchronized.kt.expected
@@ -62,9 +62,9 @@ public open class Synchronized {
                 var index: Int = 0
                 var counter: Int = 0
                 while (index < values!!.size) {
-                    val v6: Int = counter + values[index]
+                    val value: Int = counter + values[index]
                     index++
-                    counter = v6
+                    counter = value
                 }
                 Synchronized.counter = counter
                 return counter

--- a/dexdec/tests/testcases/expected/Synchronized.kt.expected
+++ b/dexdec/tests/testcases/expected/Synchronized.kt.expected
@@ -4,87 +4,87 @@ public open class Synchronized {
 
         private var counter: Int = 0
 
-        public fun computeInSync(p0: Int, p1: Int): Int {
+        public fun computeInSync(i: Int, i2: Int): Int {
             synchronized(Synchronized.lock!!) {
-                val counter: Int = p0 + p1
+                val counter: Int = i + i2
                 Synchronized.counter = counter
                 return counter
             }
         }
 
-        public fun multiExit(p0: Int, p1: Int): Int {
+        public fun multiExit(i: Int, i2: Int): Int {
             synchronized(Synchronized.lock!!) {
-                if (p0 < 0) {
+                if (i < 0) {
                     return -1
                 }
-                if (p1 < 0) {
+                if (i2 < 0) {
                     return -2
                 }
-                Synchronized.counter = p0 + p1
+                Synchronized.counter = i + i2
             }
             return Synchronized.counter
         }
 
-        public fun nestedSync(any: Any?, p1: Int): Int {
+        public fun nestedSync(any: Any?, i: Int): Int {
             synchronized(Synchronized.lock!!) {
                 synchronized(any!!) {
-                    Synchronized.counter = p1 * 2
+                    Synchronized.counter = i * 2
                 }
             }
             return Synchronized.counter
         }
 
-        public fun simpleSync(p0: Int): Int {
+        public fun simpleSync(i: Int): Int {
             synchronized(Synchronized.lock!!) {
-                Synchronized.counter = p0
+                Synchronized.counter = i
                 return Synchronized.counter
             }
         }
 
-        public @kotlin.jvm.Synchronized fun syncMethod(p0: Int): Int {
-            Synchronized.counter = p0
+        public @kotlin.jvm.Synchronized fun syncMethod(i: Int): Int {
+            Synchronized.counter = i
             return Synchronized.counter
         }
 
-        public fun syncWithCondition(p0: Int): Int {
+        public fun syncWithCondition(i: Int): Int {
             synchronized(Synchronized.lock!!) {
-                if (p0 <= 0) {
-                    Synchronized.counter = -p0
+                if (i <= 0) {
+                    Synchronized.counter = -i
                 } else {
-                    Synchronized.counter = p0
+                    Synchronized.counter = i
                 }
             }
             return Synchronized.counter
         }
 
-        public fun syncWithLoop(values: IntArray?): Int {
+        public fun syncWithLoop(iArr: IntArray?): Int {
             synchronized(Synchronized.lock!!) {
                 var index: Int = 0
                 var counter: Int = 0
-                while (index < values!!.size) {
-                    val value: Int = counter + values[index]
+                while (index < iArr!!.size) {
+                    val i: Int = counter + iArr[index]
                     index++
-                    counter = value
+                    counter = i
                 }
                 Synchronized.counter = counter
                 return counter
             }
         }
 
-        public fun syncWithReturn(p0: Int): Int {
+        public fun syncWithReturn(i: Int): Int {
             synchronized(Synchronized.lock!!) {
-                if (p0 != 0) {
-                    Synchronized.counter = 100 / p0
+                if (i != 0) {
+                    Synchronized.counter = 100 / i
                     return Synchronized.counter
                 }
                 return -1
             }
         }
 
-        public fun syncWithTry(p0: Int): Int {
+        public fun syncWithTry(i: Int): Int {
             synchronized(Synchronized.lock!!) {
                 try {
-                    Synchronized.counter = 100 / p0
+                    Synchronized.counter = 100 / i
                 } catch (exception: ArithmeticException) {
                     Synchronized.counter = -1
                 }
@@ -92,13 +92,13 @@ public open class Synchronized {
             return Synchronized.counter
         }
 
-        public fun tryWithSync(p0: Int): Int {
+        public fun tryWithSync(i: Int): Int {
             try {
                 synchronized(Synchronized.lock!!) {
-                    if (p0 == 0) {
+                    if (i == 0) {
                         throw RuntimeException("zero")
                     }
-                    Synchronized.counter = p0
+                    Synchronized.counter = i
                 }
             } catch (exception: RuntimeException) {
                 return -1

--- a/dexdec/tests/testcases/expected/SynchronizedAdvanced.kt.expected
+++ b/dexdec/tests/testcases/expected/SynchronizedAdvanced.kt.expected
@@ -1,7 +1,7 @@
 public open class SynchronizedAdvanced {
-    public open fun syncOnThis(p0: Int): Int {
+    public open fun syncOnThis(i: Int): Int {
         synchronized(this) {
-            SynchronizedAdvanced.value = p0
+            SynchronizedAdvanced.value = i
         }
         return SynchronizedAdvanced.value
     }
@@ -13,16 +13,16 @@ public open class SynchronizedAdvanced {
 
         private var value: Int = 0
 
-        public fun deepNesting(values: IntArray?): Int {
+        public fun deepNesting(iArr: IntArray?): Int {
             var index: Int = 0
             var remaining: Int = 0
-            while (index < values!!.size) {
+            while (index < iArr!!.size) {
                 val lock1: Any? = SynchronizedAdvanced.lock1
                 var condition: Boolean = false
                 synchronized(lock1!!) {
                     var step: Int = 0
                     try {
-                        step = 10 / values[index]
+                        step = 10 / iArr[index]
                     } catch (exception: ArithmeticException) {
                         remaining--
                         condition = true
@@ -36,23 +36,23 @@ public open class SynchronizedAdvanced {
             return remaining
         }
 
-        private fun helper(p0: Int): Int {
-            return p0 * 2
+        private fun helper(i: Int): Int {
+            return i * 2
         }
 
-        public fun sequentialSync(p0: Int, p1: Int): Int {
-            var value: Int
+        public fun sequentialSync(i: Int, i2: Int): Int {
+            var i3: Int
             synchronized(SynchronizedAdvanced.lock1!!) {
-                value = p0 + 1
+                i3 = i + 1
             }
             synchronized(SynchronizedAdvanced.lock2!!) {
-                return value + p1
+                return i3 + i2
             }
         }
 
-        public fun syncMultiCatch(p0: Int): Int {
+        public fun syncMultiCatch(i: Int): Int {
             synchronized(SynchronizedAdvanced.lock1!!) {
-                if (p0 < 0) {
+                if (i < 0) {
                     try {
                         throw IllegalArgumentException()
                     } catch (exception2: ArithmeticException) {
@@ -62,7 +62,7 @@ public open class SynchronizedAdvanced {
                     }
                 }
                 try {
-                    return 100 / p0
+                    return 100 / i
                 } catch (exception2: ArithmeticException) {
                     return -1
                 } catch (exception: IllegalArgumentException) {
@@ -71,57 +71,57 @@ public open class SynchronizedAdvanced {
             }
         }
 
-        public fun syncOnClass(p0: Int): Int {
+        public fun syncOnClass(i: Int): Int {
             synchronized(SynchronizedAdvanced::class.java!!) {
-                SynchronizedAdvanced.value = p0
+                SynchronizedAdvanced.value = i
             }
             return SynchronizedAdvanced.value
         }
 
-        public fun syncWhileLoop(p0: Int): Int {
-            var p0: Int = p0
+        public fun syncWhileLoop(i: Int): Int {
+            var i: Int = i
             synchronized(SynchronizedAdvanced.lock1!!) {
                 var result: Int = 0
-                while (p0 > 0) {
-                    val value: Int = p0 / 2
-                    p0 = value
-                    p0 = value
+                while (i > 0) {
+                    val i2: Int = i / 2
+                    i = i2
+                    i = i2
                     result++
-                    p0 = value
+                    i = i2
                 }
                 return result
             }
         }
 
-        public fun syncWithBreak(values: IntArray?): Int {
+        public fun syncWithBreak(iArr: IntArray?): Int {
             synchronized(SynchronizedAdvanced.lock1!!) {
                 var index: Int = 0
-                var result: Int = 0
-                while (index < values!!.size) {
-                    if (values[index] < 0) {
-                        return result
+                var i: Int = 0
+                while (index < iArr!!.size) {
+                    if (iArr[index] < 0) {
+                        return i
                     }
-                    val value: Int = result + values[index]
+                    val i2: Int = i + iArr[index]
                     index++
-                    result = value
+                    i = i2
                 }
-                return result
+                return i
             }
         }
 
-        public fun syncWithCall(p0: Int): Int {
+        public fun syncWithCall(i: Int): Int {
             synchronized(SynchronizedAdvanced.lock1!!) {
-                return SynchronizedAdvanced.helper(p0)
+                return SynchronizedAdvanced.helper(i)
             }
         }
 
-        public fun syncWithContinue(values: IntArray?): Int {
+        public fun syncWithContinue(iArr: IntArray?): Int {
             synchronized(SynchronizedAdvanced.lock1!!) {
                 var index: Int = 0
                 var total: Int = 0
-                while (index < values!!.size) {
-                    if (values[index] != 0) {
-                        total += values[index]
+                while (index < iArr!!.size) {
+                    if (iArr[index] != 0) {
+                        total += iArr[index]
                     }
                     index++
                 }
@@ -129,11 +129,11 @@ public open class SynchronizedAdvanced {
             }
         }
 
-        public fun syncWithFinally(p0: Int): Int {
+        public fun syncWithFinally(i: Int): Int {
             synchronized(SynchronizedAdvanced.lock1!!) {
                 var value: Int
                 try {
-                    value = 100 / p0
+                    value = 100 / i
                 } catch (exception: ArithmeticException) {
                     return -1
                 } finally {
@@ -143,10 +143,10 @@ public open class SynchronizedAdvanced {
             }
         }
 
-        public fun syncWithSwitch(p0: Int): Int {
+        public fun syncWithSwitch(i: Int): Int {
             var result: Int = 0
             synchronized(SynchronizedAdvanced.lock1!!) {
-                when (p0) {
+                when (i) {
                     1 -> {
                         result = 10
                     }

--- a/dexdec/tests/testcases/expected/SynchronizedAdvanced.kt.expected
+++ b/dexdec/tests/testcases/expected/SynchronizedAdvanced.kt.expected
@@ -41,12 +41,12 @@ public open class SynchronizedAdvanced {
         }
 
         public fun sequentialSync(p0: Int, p1: Int): Int {
-            var v3: Int
+            var value: Int
             synchronized(SynchronizedAdvanced.lock1!!) {
-                v3 = p0 + 1
+                value = p0 + 1
             }
             synchronized(SynchronizedAdvanced.lock2!!) {
-                return v3 + p1
+                return value + p1
             }
         }
 
@@ -83,11 +83,11 @@ public open class SynchronizedAdvanced {
             synchronized(SynchronizedAdvanced.lock1!!) {
                 var result: Int = 0
                 while (p0 > 0) {
-                    val v5: Int = p0 / 2
-                    p0 = v5
-                    p0 = v5
+                    val value: Int = p0 / 2
+                    p0 = value
+                    p0 = value
                     result++
-                    p0 = v5
+                    p0 = value
                 }
                 return result
             }
@@ -101,9 +101,9 @@ public open class SynchronizedAdvanced {
                     if (values[index] < 0) {
                         return result
                     }
-                    val v6: Int = result + values[index]
+                    val value: Int = result + values[index]
                     index++
-                    result = v6
+                    result = value
                 }
                 return result
             }

--- a/dexdec/tests/testcases/expected/TryCatch.kt.expected
+++ b/dexdec/tests/testcases/expected/TryCatch.kt.expected
@@ -1,8 +1,8 @@
 public open class TryCatch {
     companion object {
-        public fun divide(p0: Int, p1: Int): Int {
+        public fun divide(i: Int, i2: Int): Int {
             try {
-                return p0 / p1
+                return i / i2
             } catch (exception: ArithmeticException) {
                 return 0
             }

--- a/dexdec/tests/testcases/expected/TryCatchFinally.kt.expected
+++ b/dexdec/tests/testcases/expected/TryCatchFinally.kt.expected
@@ -1,7 +1,7 @@
 public open class TryCatchFinally {
     companion object {
-        public fun simpleTryCatch(p0: Int): Int {
-            if (p0 != 0) {
+        public fun simpleTryCatch(i: Int): Int {
+            if (i != 0) {
                 return 1
             }
             try {


### PR DESCRIPTION
## Summary

The constrained name solver only assigns high-score source bindings, so unnamed locals fell back to register-shaped `v12` names.

Two commits:

1. After the solver, name remaining source bindings from type, role, or `value`, and use the same fallback during lowering instead of `v{register}`.
2. Align those fallbacks with JADX 1.5.5 `ApplyVariableNames` (`i` / `str` / `obj` / `iArr`) and `ProcessKotlinInternals` (`Intrinsics.checkNotNull*(x, "name")`). Keep high-score semantic names such as `result` when the solver already recovered them.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dexdec --lib`
- `cargo test -p dexdec --test expected_test` (snapshot updates are rename-only)
- Sample shards vs current `main` (same class lists): register-style local decls **181 / 212 / 319 → 0**; leftover `vN` tokens are obfuscated type/method names, not registers
- Fixture `finally` / `synchronized` counts unchanged; no new `goto`, empty files, or brace-balance failures

## Review notes

Standalone. No overlap with the FunctionN or suspend-ABI PRs. The JADX alias commit should be reviewed after the no-`vN` fallback commit.